### PR TITLE
make Trace class public

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -28,7 +28,7 @@ import java.util.Optional;
  * Represents a trace as an ordered list of non-completed spans. Supports adding and removing of spans. This class is
  * not thread-safe and is intended to be used in a thread-local context.
  */
-final class Trace {
+public final class Trace {
 
     private final Deque<OpenSpan> stack;
     private final boolean isObservable;


### PR DESCRIPTION
This is needed to delegate all remoting tracing calls to `tracing-java`. Since [Tracer.getAndClearTrace()](https://github.com/palantir/tracing-java/blob/develop/tracing/src/main/java/com/palantir/tracing/Tracer.java#L246-L251) is public and returns Tracer type, it makes sense for Tracer to be public