### PR TITLE
compatibility check against tracer remoting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,18 @@ Note that span observers are static; a server typically subscribes span observer
 Libraries should never register span observers (since they can trample observers registered by consumers of the library
 whose themselves register observers).
 
+## Compatibility Check Against Remoting Tracer
+Prior to [http-remoting 3.43.0](https://github.com/palantir/http-remoting/releases/tag/3.43.0), remoting tracer has its
+own ThreadLocal to keep track of the current trace. This would result two ThreadLocals independently tracking their own
+ traces if any older version of `com.palantir.remoting3.tracing.Trace` were used in conjunction with 
+ `com.palantir.tracing.Tracer`. To prevent consumers from getting into this bad state, `com.palantir.tracing.Tracer` will
+ do compatibility check against remoting Tracer on class load and throws an exception if any older version of 
+ `com.palantir.remoting3.tracing.Trace` is found in the classpath.
+ 
+If you find it necessary to have both the older version of `com.palantir.remoting3.tracing.Trace` and 
+the `com.palantir.tracing.Tracer` in the classpath, you can disable this compatibility check by setting the 
+`tracing.remoting.compat.check.enabled` system property to `false`. 
+
 ## License
 
 This repository is made available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/tracing-jaxrs/versions.lock
+++ b/tracing-jaxrs/versions.lock
@@ -21,6 +21,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.sls.versions:sls-versions",
                 "com.palantir.tracing:tracing",
                 "com.palantir.tracing:tracing-api"
             ]
@@ -43,6 +44,12 @@
                 "com.palantir.tracing:tracing"
             ]
         },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions"
+            ]
+        },
         "com.google.guava:guava": {
             "locked": "20.0",
             "transitive": [
@@ -50,8 +57,22 @@
                 "com.palantir.tracing:tracing"
             ]
         },
+        "com.palantir.safe-logging:preconditions": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.sls.versions:sls-versions"
+            ]
+        },
         "com.palantir.safe-logging:safe-logging": {
             "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions",
+                "com.palantir.sls.versions:sls-versions",
+                "com.palantir.tracing:tracing"
+            ]
+        },
+        "com.palantir.sls.versions:sls-versions": {
+            "locked": "0.9.0",
             "transitive": [
                 "com.palantir.tracing:tracing"
             ]
@@ -71,6 +92,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.12",
             "transitive": [
+                "com.palantir.sls.versions:sls-versions",
                 "com.palantir.tracing:tracing"
             ]
         }
@@ -97,6 +119,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.sls.versions:sls-versions",
                 "com.palantir.tracing:tracing",
                 "com.palantir.tracing:tracing-api"
             ]
@@ -119,6 +142,12 @@
                 "com.palantir.tracing:tracing"
             ]
         },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions"
+            ]
+        },
         "com.google.guava:guava": {
             "locked": "20.0",
             "transitive": [
@@ -126,8 +155,22 @@
                 "com.palantir.tracing:tracing"
             ]
         },
+        "com.palantir.safe-logging:preconditions": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.sls.versions:sls-versions"
+            ]
+        },
         "com.palantir.safe-logging:safe-logging": {
             "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions",
+                "com.palantir.sls.versions:sls-versions",
+                "com.palantir.tracing:tracing"
+            ]
+        },
+        "com.palantir.sls.versions:sls-versions": {
+            "locked": "0.9.0",
             "transitive": [
                 "com.palantir.tracing:tracing"
             ]
@@ -147,6 +190,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.12",
             "transitive": [
+                "com.palantir.sls.versions:sls-versions",
                 "com.palantir.tracing:tracing"
             ]
         }

--- a/tracing-jersey/versions.lock
+++ b/tracing-jersey/versions.lock
@@ -21,6 +21,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.sls.versions:sls-versions",
                 "com.palantir.tracing:tracing",
                 "com.palantir.tracing:tracing-api"
             ]
@@ -43,6 +44,12 @@
                 "com.palantir.tracing:tracing"
             ]
         },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions"
+            ]
+        },
         "com.google.guava:guava": {
             "locked": "20.0",
             "transitive": [
@@ -50,8 +57,22 @@
                 "com.palantir.tracing:tracing"
             ]
         },
+        "com.palantir.safe-logging:preconditions": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.sls.versions:sls-versions"
+            ]
+        },
         "com.palantir.safe-logging:safe-logging": {
             "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions",
+                "com.palantir.sls.versions:sls-versions",
+                "com.palantir.tracing:tracing"
+            ]
+        },
+        "com.palantir.sls.versions:sls-versions": {
+            "locked": "0.9.0",
             "transitive": [
                 "com.palantir.tracing:tracing"
             ]
@@ -181,6 +202,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.12",
             "transitive": [
+                "com.palantir.sls.versions:sls-versions",
                 "com.palantir.tracing:tracing"
             ]
         }
@@ -207,6 +229,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.sls.versions:sls-versions",
                 "com.palantir.tracing:tracing",
                 "com.palantir.tracing:tracing-api"
             ]
@@ -229,6 +252,12 @@
                 "com.palantir.tracing:tracing"
             ]
         },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions"
+            ]
+        },
         "com.google.guava:guava": {
             "locked": "20.0",
             "transitive": [
@@ -236,8 +265,22 @@
                 "com.palantir.tracing:tracing"
             ]
         },
+        "com.palantir.safe-logging:preconditions": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.sls.versions:sls-versions"
+            ]
+        },
         "com.palantir.safe-logging:safe-logging": {
             "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions",
+                "com.palantir.sls.versions:sls-versions",
+                "com.palantir.tracing:tracing"
+            ]
+        },
+        "com.palantir.sls.versions:sls-versions": {
+            "locked": "0.9.0",
             "transitive": [
                 "com.palantir.tracing:tracing"
             ]
@@ -367,6 +410,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.12",
             "transitive": [
+                "com.palantir.sls.versions:sls-versions",
                 "com.palantir.tracing:tracing"
             ]
         }

--- a/tracing-okhttp3/versions.lock
+++ b/tracing-okhttp3/versions.lock
@@ -21,6 +21,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.sls.versions:sls-versions",
                 "com.palantir.tracing:tracing",
                 "com.palantir.tracing:tracing-api"
             ]
@@ -43,6 +44,12 @@
                 "com.palantir.tracing:tracing"
             ]
         },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions"
+            ]
+        },
         "com.google.guava:guava": {
             "locked": "20.0",
             "transitive": [
@@ -50,8 +57,22 @@
                 "com.palantir.tracing:tracing"
             ]
         },
+        "com.palantir.safe-logging:preconditions": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.sls.versions:sls-versions"
+            ]
+        },
         "com.palantir.safe-logging:safe-logging": {
             "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions",
+                "com.palantir.sls.versions:sls-versions",
+                "com.palantir.tracing:tracing"
+            ]
+        },
+        "com.palantir.sls.versions:sls-versions": {
+            "locked": "0.9.0",
             "transitive": [
                 "com.palantir.tracing:tracing"
             ]
@@ -77,6 +98,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.12",
             "transitive": [
+                "com.palantir.sls.versions:sls-versions",
                 "com.palantir.tracing:tracing"
             ]
         }
@@ -103,6 +125,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.sls.versions:sls-versions",
                 "com.palantir.tracing:tracing",
                 "com.palantir.tracing:tracing-api"
             ]
@@ -125,6 +148,12 @@
                 "com.palantir.tracing:tracing"
             ]
         },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions"
+            ]
+        },
         "com.google.guava:guava": {
             "locked": "20.0",
             "transitive": [
@@ -132,8 +161,22 @@
                 "com.palantir.tracing:tracing"
             ]
         },
+        "com.palantir.safe-logging:preconditions": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.sls.versions:sls-versions"
+            ]
+        },
         "com.palantir.safe-logging:safe-logging": {
             "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions",
+                "com.palantir.sls.versions:sls-versions",
+                "com.palantir.tracing:tracing"
+            ]
+        },
+        "com.palantir.sls.versions:sls-versions": {
+            "locked": "0.9.0",
             "transitive": [
                 "com.palantir.tracing:tracing"
             ]
@@ -159,6 +202,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.12",
             "transitive": [
+                "com.palantir.sls.versions:sls-versions",
                 "com.palantir.tracing:tracing"
             ]
         }

--- a/tracing/build.gradle
+++ b/tracing/build.gradle
@@ -26,14 +26,17 @@ dependencies {
     compile "com.fasterxml.jackson.module:jackson-module-afterburner"
     compile "com.google.guava:guava"
     compile "com.palantir.safe-logging:safe-logging"
+    compile "com.palantir.sls.versions:sls-versions"
     compile "org.slf4j:slf4j-api"
 
     testCompile "ch.qos.logback:logback-classic"
+    testCompile "com.palantir.remoting3:tracing"
+    testCompile "io.zipkin.java:zipkin"
     testCompile "junit:junit"
     testCompile "org.assertj:assertj-core"
     testCompile "org.jmock:jmock"
     testCompile "org.mockito:mockito-core"
-    testCompile "io.zipkin.java:zipkin"
-
+    
     processor "org.immutables:value"
 }
+

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -42,9 +42,13 @@ import org.slf4j.MDC;
  * This class is thread-safe.
  */
 public final class Tracer {
+
     private static final Logger log = LoggerFactory.getLogger(Tracer.class);
     private static final OrderableSlsVersion MIN_COMPAT_REMOTING_TRACER_VER = OrderableSlsVersion.valueOf("3.43.0");
     private static final Optional<OrderableSlsVersion> REMOTING_TRACER_VER = getRemotingTracerVersion();
+
+    // system property used to disable compatibility check against remoting tracer
+    private static final String REMOTING_TRACER_COMPAT_CHECK_SYSTEM_PROPERTY = "tracing.remoting.compat.check.enabled";
 
     private Tracer() {
         checkForRemotingTracerCompatibility(REMOTING_TRACER_VER);
@@ -282,7 +286,11 @@ public final class Tracer {
     }
 
     protected static void checkForRemotingTracerCompatibility(Optional<OrderableSlsVersion> remotingTracerVer) {
-        if (remotingTracerVer.isPresent()
+        Boolean enableCompatCheck = Optional.ofNullable(
+                System.getProperty(REMOTING_TRACER_COMPAT_CHECK_SYSTEM_PROPERTY))
+                .map(Boolean::valueOf).orElse(Boolean.TRUE);
+
+        if (enableCompatCheck && remotingTracerVer.isPresent()
                 && VersionComparator.INSTANCE.compare(remotingTracerVer.get(), MIN_COMPAT_REMOTING_TRACER_VER) < 0) {
             throw new IllegalStateException(String.format(
                     "Found incompatible remoting tracer version %s in the classpath, expected %s or greater",

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -44,14 +44,14 @@ import org.slf4j.MDC;
 public final class Tracer {
 
     private static final Logger log = LoggerFactory.getLogger(Tracer.class);
-    private static final OrderableSlsVersion MIN_COMPAT_REMOTING_TRACER_VER = OrderableSlsVersion.valueOf("3.43.0");
-    private static final Optional<OrderableSlsVersion> REMOTING_TRACER_VER = getRemotingTracerVersion();
 
     // system property used to disable compatibility check against remoting tracer
     private static final String REMOTING_TRACER_COMPAT_CHECK_SYSTEM_PROPERTY = "tracing.remoting.compat.check.enabled";
 
-    private Tracer() {
-        checkForRemotingTracerCompatibility(REMOTING_TRACER_VER);
+    private Tracer() {}
+
+    static {
+        checkForRemotingTracerCompatibility(getRemotingTracerVersion());
     }
 
     // Thread-safe since thread-local
@@ -286,16 +286,17 @@ public final class Tracer {
     }
 
     protected static void checkForRemotingTracerCompatibility(Optional<OrderableSlsVersion> remotingTracerVer) {
+        OrderableSlsVersion minCompatibleVersion = OrderableSlsVersion.valueOf("3.43.0");
         Boolean enableCompatCheck = Optional.ofNullable(
                 System.getProperty(REMOTING_TRACER_COMPAT_CHECK_SYSTEM_PROPERTY))
                 .map(Boolean::valueOf).orElse(Boolean.TRUE);
 
         if (enableCompatCheck && remotingTracerVer.isPresent()
-                && VersionComparator.INSTANCE.compare(remotingTracerVer.get(), MIN_COMPAT_REMOTING_TRACER_VER) < 0) {
+                && VersionComparator.INSTANCE.compare(remotingTracerVer.get(), minCompatibleVersion) < 0) {
             throw new IllegalStateException(String.format(
                     "Found incompatible remoting tracer version %s in the classpath, expected %s or greater",
                     remotingTracerVer.get(),
-                    MIN_COMPAT_REMOTING_TRACER_VER));
+                    minCompatibleVersion));
         }
     }
 

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -276,6 +276,18 @@ public final class TracerTest {
                     "Found incompatible remoting tracer version 3.42.0 in the classpath, expected 3.43.0 or greater",
                     e.getMessage());
         }
+
+        // check disabled
+        System.setProperty("tracing.remoting.compat.check.enabled", "false");
+        Tracer.checkForRemotingTracerCompatibility(Optional.of(OrderableSlsVersion.valueOf("3.42.0")));
+
+        // check enabled
+        System.clearProperty("tracing.remoting.compat.check.enabled");
+        try {
+            Tracer.checkForRemotingTracerCompatibility(Optional.of(OrderableSlsVersion.valueOf("3.42.0")));
+        } catch (IllegalStateException e) {
+            // expected
+        }
     }
 
     private static Span startAndCompleteSpan() {

--- a/tracing/versions.lock
+++ b/tracing/versions.lock
@@ -21,6 +21,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.sls.versions:sls-versions",
                 "com.palantir.tracing:tracing-api"
             ]
         },
@@ -33,20 +34,42 @@
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
             "locked": "2.9.5"
         },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions"
+            ]
+        },
         "com.google.guava:guava": {
             "locked": "20.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava"
             ]
         },
+        "com.palantir.safe-logging:preconditions": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.sls.versions:sls-versions"
+            ]
+        },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "1.3.0"
+            "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions",
+                "com.palantir.sls.versions:sls-versions"
+            ]
+        },
+        "com.palantir.sls.versions:sls-versions": {
+            "locked": "0.9.0"
         },
         "com.palantir.tracing:tracing-api": {
             "project": true
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.12"
+            "locked": "1.7.12",
+            "transitive": [
+                "com.palantir.sls.versions:sls-versions"
+            ]
         }
     },
     "runtime": {
@@ -71,6 +94,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.sls.versions:sls-versions",
                 "com.palantir.tracing:tracing-api"
             ]
         },
@@ -83,20 +107,42 @@
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
             "locked": "2.9.5"
         },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions"
+            ]
+        },
         "com.google.guava:guava": {
             "locked": "20.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava"
             ]
         },
+        "com.palantir.safe-logging:preconditions": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.sls.versions:sls-versions"
+            ]
+        },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "1.3.0"
+            "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions",
+                "com.palantir.sls.versions:sls-versions"
+            ]
+        },
+        "com.palantir.sls.versions:sls-versions": {
+            "locked": "0.9.0"
         },
         "com.palantir.tracing:tracing-api": {
             "project": true
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.12"
+            "locked": "1.7.12",
+            "transitive": [
+                "com.palantir.sls.versions:sls-versions"
+            ]
         }
     }
 }

--- a/versions.props
+++ b/versions.props
@@ -2,6 +2,7 @@ ch.qos.logback:logback-classic = 1.1.7
 com.fasterxml.jackson.*:jackson-* = 2.9.5
 com.google.guava:guava = 20.0
 com.palantir.safe-logging:* = 1.3.0
+com.palantir.sls.versions:sls-versions = 0.9.0
 com.squareup.okhttp3:okhttp = 3.9.0
 io.dropwizard:dropwizard-* = 1.3.1
 io.zipkin.java:* = 1.13.1
@@ -14,3 +15,6 @@ org.immutables:value = 2.3.10
 org.jmock:jmock = 2.8.2
 org.mockito:mockito-core = 2.18.3
 org.slf4j:slf4j-api = 1.7.12
+
+## test
+com.palantir.remoting3:tracing = 3.43.0


### PR DESCRIPTION
tracing-java now check remoting tracing version to ensure all tracings are done in a single thread, see more details https://github.com/palantir/http-remoting/pull/799. If remoting version is lower than 3.43.0, an exception will be thrown. 

I am not sure what is the best way of testing incompatible case, may be some integration test specifically for that. Any suggestions?