### PR TITLE
Trace thread state is removed when root spans are completed

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -118,6 +118,7 @@ public final class Tracer {
 
         Trace trace = getOrCreateCurrentTrace();
         Optional<OpenSpan> prevState = trace.top();
+        // Avoid lambda allocation in hot paths
         if (prevState.isPresent()) {
             spanBuilder.parentSpanId(prevState.get().getSpanId());
         }
@@ -172,6 +173,7 @@ public final class Tracer {
 
         // Notify subscribers iff trace is observable
         if (maybeSpan.isPresent() && trace.isObservable()) {
+            // Avoid lambda allocation in hot paths
             notifyObservers(maybeSpan.get());
         }
 

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -141,11 +141,14 @@ public final class Tracer {
      * Like {@link #fastCompleteSpan()}, but adds {@code metadata} to the current span being completed.
      */
     public static void fastCompleteSpan(Map<String, String> metadata) {
-        if (isTraceObservable()) {
-            String traceId = getTraceId();
-            popCurrentSpan()
-                    .map(openSpan -> toSpan(openSpan, metadata, traceId))
-                    .ifPresent(Tracer::notifyObservers);
+        Trace trace = currentTrace.get();
+        if (trace != null) {
+            boolean observable = isTraceObservable();
+            Optional<OpenSpan> span = popCurrentSpan();
+            if (observable) {
+                span.map(openSpan -> toSpan(openSpan, metadata, trace.getTraceId()))
+                        .ifPresent(Tracer::notifyObservers);
+            }
         }
     }
 

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -251,6 +251,11 @@ public final class Tracer {
         Tracer.sampler = sampler;
     }
 
+    /** Returns true if there is an active trace on this thread. */
+    public static boolean hasTraceId() {
+        return currentTrace.get() != null;
+    }
+
     /** Returns the globally unique identifier for this thread's trace. */
     public static String getTraceId() {
         return Preconditions.checkNotNull(currentTrace.get(), "There is no root span").getTraceId();

--- a/tracing/src/test/java/com/palantir/tracing/CloseableTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/CloseableTracerTest.java
@@ -33,8 +33,8 @@ public final class CloseableTracerTest {
     @Test
     public void startsAndClosesSpan() {
         try (CloseableTracer tracer = CloseableTracer.startSpan("foo")) {
-            assertThat(Tracer.copyTrace().top()).isNotEmpty();
+            assertThat(Tracer.copyTrace().get().top()).isNotEmpty();
         }
-        assertThat(Tracer.copyTrace().top()).isEmpty();
+        assertThat(Tracer.getAndClearTrace().top()).isEmpty();
     }
 }

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -281,6 +281,18 @@ public final class TracerTest {
         assertThat(traceIds.size()).isEqualTo(2);
     }
 
+    @Test
+    public void testHasTraceId() {
+        assertThat(Tracer.hasTraceId()).isEqualTo(false);
+        Tracer.startSpan("testSpan");
+        try {
+            assertThat(Tracer.hasTraceId()).isEqualTo(true);
+        } finally {
+            Tracer.completeSpan();
+        }
+        assertThat(Tracer.hasTraceId()).isEqualTo(false);
+    }
+
     private static Span startAndCompleteSpan() {
         Tracer.startSpan("operation");
         return Tracer.completeSpan().get();

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.Lists;
 import com.palantir.tracing.api.OpenSpan;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -374,11 +375,12 @@ public final class TracersTest {
     }
 
     private static List<OpenSpan> getCurrentFullTrace() {
-        Trace trace = Tracer.copyTrace();
-        List<OpenSpan> spans = Lists.newArrayList();
-        while (!trace.isEmpty()) {
-            spans.add(trace.pop().get());
-        }
-        return spans;
+        return Tracer.copyTrace().map(trace -> {
+            List<OpenSpan> spans = Lists.newArrayList();
+            while (!trace.isEmpty()) {
+                spans.add(trace.pop().get());
+            }
+            return spans;
+        }).orElse(Collections.emptyList());
     }
 }


### PR DESCRIPTION
Multiple root spans are not allowed, traceId state should not
leak between multiple root spans.