### PR TITLE
Ensure checkstyle can be downloaded

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ apply plugin: 'com.palantir.git-version'
 apply plugin: 'com.palantir.baseline'
 
 repositories {
+    jcenter()
     maven { url  "http://palantir.bintray.com/releases" }
 }
 


### PR DESCRIPTION
This should fix checkstyle failures on develop.

(I accidentally merged https://github.com/palantir/tracing-java/pull/19 too early)

