### PR TITLE
fix #30: Sampling is disabled by default

### DIFF
--- a/tracing-okhttp3/src/test/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptorTest.java
+++ b/tracing-okhttp3/src/test/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.palantir.tracing.AlwaysSampler;
 import com.palantir.tracing.Tracer;
 import com.palantir.tracing.Tracers;
 import com.palantir.tracing.api.OpenSpan;
@@ -61,6 +62,7 @@ public final class OkhttpTraceInterceptorTest {
         Request request = new Request.Builder().url("http://localhost").build();
         when(chain.request()).thenReturn(request);
         Tracer.subscribe("", observer);
+        Tracer.setSampler(AlwaysSampler.INSTANCE);
     }
 
     @After

--- a/tracing/src/main/java/com/palantir/tracing/NeverSampler.java
+++ b/tracing/src/main/java/com/palantir/tracing/NeverSampler.java
@@ -1,0 +1,26 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tracing;
+
+public enum NeverSampler implements TraceSampler {
+    INSTANCE;
+
+    @Override
+    public boolean sample() {
+        return false;
+    }
+}

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -54,7 +54,7 @@ public final class Tracer {
     private static volatile List<SpanObserver> observersList = ImmutableList.of();
 
     // Thread-safe since stateless
-    private static volatile TraceSampler sampler = AlwaysSampler.INSTANCE;
+    private static volatile TraceSampler sampler = NeverSampler.INSTANCE;
 
     /**
      * Creates a new trace, but does not set it as the current trace. The new trace is {@link Trace#isObservable

--- a/tracing/src/test/java/com/palantir/tracing/AsyncSlf4jSpanObserverTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/AsyncSlf4jSpanObserverTest.java
@@ -80,6 +80,7 @@ public final class AsyncSlf4jSpanObserverTest {
 
         originalLevel = logger.getLevel();
         logger.setLevel(Level.TRACE);
+        Tracer.setSampler(AlwaysSampler.INSTANCE);
     }
 
     @After


### PR DESCRIPTION
Previously the default configuration sampled every operation.
Any application using a tracing-aware client would send every
request with `X-B3-Sampled: 1`, so even if the local application
did not record sample data to disk, upstream services would
be forced to.
