### PR TITLE
Failing streaming endpoints do return trace IDs

### DIFF
--- a/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
+++ b/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
@@ -88,6 +88,9 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
             Span span = maybeSpan.get();
             headers.putSingle(TraceHttpHeaders.TRACE_ID, span.getTraceId());
         } else {
+            // When the filter is called twice (e.g. an exception is thrown in a streaming call),
+            // the current trace will be empty. To allow clients to still get the trace ID corresponding to
+            // the failure, we retrieve it from the requestContext.
             Optional.ofNullable(requestContext.getProperty(TRACE_ID_PROPERTY_NAME))
                     .ifPresent(s -> headers.putSingle(TraceHttpHeaders.TRACE_ID, s));
         }

--- a/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
+++ b/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
@@ -87,6 +87,9 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
         if (maybeSpan.isPresent()) {
             Span span = maybeSpan.get();
             headers.putSingle(TraceHttpHeaders.TRACE_ID, span.getTraceId());
+        } else {
+            Optional.ofNullable(requestContext.getProperty(TRACE_ID_PROPERTY_NAME))
+                    .ifPresent(s -> headers.putSingle(TraceHttpHeaders.TRACE_ID, s));
         }
     }
 


### PR DESCRIPTION
## Before this PR
A failing streaming endpoint would not return the trace ID as a response header.

## After this PR
Currently this PR doesn't fix the issue, it just adds unit tests that show the problem.