### PR TITLE
[fix] Open a new span when wrapping with a new trace

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ThreadLocalRandom;
 public final class Tracers {
     /** The key under which trace ids are inserted into SLF4J {@link org.slf4j.MDC MDCs}. */
     public static final String TRACE_ID_KEY = "traceId";
+    private static final String ROOT_SPAN_OPERATION = "root";
     private static final char[] HEX_DIGITS =
             {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
@@ -148,8 +149,10 @@ public final class Tracers {
 
             try {
                 Tracer.initTrace(Optional.empty(), Tracers.randomId());
+                Tracer.startSpan(ROOT_SPAN_OPERATION);
                 return delegate.call();
             } finally {
+                Tracer.completeSpan();
                 // restore the trace
                 Tracer.setTrace(originalTrace);
             }
@@ -166,8 +169,10 @@ public final class Tracers {
 
             try {
                 Tracer.initTrace(Optional.empty(), Tracers.randomId());
+                Tracer.startSpan(ROOT_SPAN_OPERATION);
                 delegate.run();
             } finally {
+                Tracer.completeSpan();
                 // restore the trace
                 Tracer.setTrace(originalTrace);
             }
@@ -187,8 +192,10 @@ public final class Tracers {
 
             try {
                 Tracer.initTrace(Optional.empty(), traceId);
+                Tracer.startSpan(ROOT_SPAN_OPERATION);
                 delegate.run();
             } finally {
+                Tracer.completeSpan();
                 // restore the trace
                 Tracer.setTrace(originalTrace);
             }

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -152,7 +152,7 @@ public final class Tracers {
                 Tracer.startSpan(ROOT_SPAN_OPERATION);
                 return delegate.call();
             } finally {
-                Tracer.completeSpan();
+                Tracer.fastCompleteSpan();
                 // restore the trace
                 Tracer.setTrace(originalTrace);
             }
@@ -172,7 +172,7 @@ public final class Tracers {
                 Tracer.startSpan(ROOT_SPAN_OPERATION);
                 delegate.run();
             } finally {
-                Tracer.completeSpan();
+                Tracer.fastCompleteSpan();
                 // restore the trace
                 Tracer.setTrace(originalTrace);
             }
@@ -195,7 +195,7 @@ public final class Tracers {
                 Tracer.startSpan(ROOT_SPAN_OPERATION);
                 delegate.run();
             } finally {
-                Tracer.completeSpan();
+                Tracer.fastCompleteSpan();
                 // restore the trace
                 Tracer.setTrace(originalTrace);
             }

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -220,7 +220,14 @@ public final class TracersTest {
             return getCurrentFullTrace();
         });
 
-        assertThat(wrappedCallable.call()).hasSize(1);
+        List<OpenSpan> spans = wrappedCallable.call();
+
+        assertThat(spans).hasSize(1);
+
+        OpenSpan span = spans.get(0);
+
+        assertThat(span.getOperation()).isEqualTo("root");
+        assertThat(span.getParentSpanId()).isEmpty();
     }
 
     @Test
@@ -278,6 +285,11 @@ public final class TracersTest {
         wrappedRunnable.run();
 
         assertThat(spans.get(0)).hasSize(1);
+
+        OpenSpan span = spans.get(0).get(0);
+
+        assertThat(span.getOperation()).isEqualTo("root");
+        assertThat(span.getParentSpanId()).isEmpty();
     }
 
     @Test
@@ -327,6 +339,11 @@ public final class TracersTest {
         wrappedRunnable.run();
 
         assertThat(spans.get(0)).hasSize(1);
+
+        OpenSpan span = spans.get(0).get(0);
+
+        assertThat(span.getOperation()).isEqualTo("root");
+        assertThat(span.getParentSpanId()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
Creating a new trace does not create a new root span. Thus all top-level calls in this trace will have no parent span. This breaks assumptions of trace log consumers who assume that there is only one root span for a given trace.

This also seems counter to the `parentId` specification in the [Zipkin API](https://github.com/openzipkin/zipkin-api/blob/5fd719b114ff2ba44f1d2757888fa123cdfb0da6/zipkin-api.yaml#L353):
> The parent span ID or absent if this the root span in a trace.

## After this PR
Creating a new trace will create a new root span.

The issue is part of the `Major API revision` milestone, but this fix does not break the API. Is a major API revision required for this change?
