### PR TITLE
Restore trace state back to cleared when wrapWithNewTrace is called with no trace state

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -270,6 +270,13 @@ public final class Tracer {
         return Preconditions.checkNotNull(currentTrace.get(), "There is no root span").getTraceId();
     }
 
+    /** Clears the current trace id and returns it if present. */
+    static Optional<Trace> getAndClearTraceIfPresent() {
+        Optional<Trace> trace = Optional.ofNullable(currentTrace.get());
+        clearCurrentTrace();
+        return trace;
+    }
+
     /** Clears the current trace id and returns (a copy of) it. */
     public static Trace getAndClearTrace() {
         Trace trace = getOrCreateCurrentTrace();

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -252,6 +252,19 @@ public final class TracerTest {
     }
 
     @Test
+    public void testGetAndClearTraceIfPresent() {
+        Trace trace = new Trace(true, "newTraceId");
+        Tracer.setTrace(trace);
+
+        Optional<Trace> nonEmptyTrace = Tracer.getAndClearTraceIfPresent();
+        assertThat(nonEmptyTrace).hasValue(trace);
+        assertThat(Tracer.hasTraceId()).isFalse();
+
+        Optional<Trace> emptyTrace = Tracer.getAndClearTraceIfPresent();
+        assertThat(emptyTrace).isEmpty();
+    }
+
+    @Test
     public void testClearAndGetTraceClearsMdc() {
         Tracer.startSpan("test");
         try {


### PR DESCRIPTION
Previously, when `Tracers::wrapWithNewTrace` was called with no trace state, the trace state would incorrectly be restored to a new trace rather than the cleared state. Now, the trace state will be appropriately returned to the cleared state.