### PR TITLE
[improvement] Distinguish Jersey and OkHttp operation names

### DIFF
--- a/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
+++ b/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
@@ -54,7 +54,7 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
                 .map(Resource::getPath)
                 .orElse("(unknown)");
 
-        String operation = requestContext.getMethod() + " " + path;
+        String operation = "Jersey: " + requestContext.getMethod() + " " + path;
         // The following strings are all nullable
         String traceId = requestContext.getHeaderString(TraceHttpHeaders.TRACE_ID);
         String spanId = requestContext.getHeaderString(TraceHttpHeaders.SPAN_ID);

--- a/tracing-jersey/src/test/java/com/palantir/tracing/jersey/TraceEnrichingFilterTest.java
+++ b/tracing-jersey/src/test/java/com/palantir/tracing/jersey/TraceEnrichingFilterTest.java
@@ -116,7 +116,7 @@ public final class TraceEnrichingFilterTest {
         assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID), is(nullValue()));
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID), is(nullValue()));
         verify(observer).consume(spanCaptor.capture());
-        assertThat(spanCaptor.getValue().getOperation(), is("GET /trace"));
+        assertThat(spanCaptor.getValue().getOperation(), is("Jersey: GET /trace"));
     }
 
     @Test
@@ -130,7 +130,7 @@ public final class TraceEnrichingFilterTest {
         assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID), is(nullValue()));
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID), is(nullValue()));
         verify(observer).consume(spanCaptor.capture());
-        assertThat(spanCaptor.getValue().getOperation(), is("POST /trace"));
+        assertThat(spanCaptor.getValue().getOperation(), is("Jersey: POST /trace"));
     }
 
     @Test
@@ -144,7 +144,7 @@ public final class TraceEnrichingFilterTest {
         assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID), is(nullValue()));
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID), is(nullValue()));
         verify(observer).consume(spanCaptor.capture());
-        assertThat(spanCaptor.getValue().getOperation(), is("GET /trace/{param}"));
+        assertThat(spanCaptor.getValue().getOperation(), is("Jersey: GET /trace/{param}"));
     }
 
     @Test
@@ -154,7 +154,7 @@ public final class TraceEnrichingFilterTest {
         assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID), is(nullValue()));
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID), is(nullValue()));
         verify(observer).consume(spanCaptor.capture());
-        assertThat(spanCaptor.getValue().getOperation(), is("GET /trace"));
+        assertThat(spanCaptor.getValue().getOperation(), is("Jersey: GET /trace"));
     }
 
     @Test
@@ -164,7 +164,7 @@ public final class TraceEnrichingFilterTest {
         assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID), is(nullValue()));
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID), is(nullValue()));
         verify(observer).consume(spanCaptor.capture());
-        assertThat(spanCaptor.getValue().getOperation(), is("GET /failing-trace"));
+        assertThat(spanCaptor.getValue().getOperation(), is("Jersey: GET /failing-trace"));
     }
 
     @Test
@@ -174,7 +174,7 @@ public final class TraceEnrichingFilterTest {
         assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID), is(nullValue()));
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID), is(nullValue()));
         verify(observer).consume(spanCaptor.capture());
-        assertThat(spanCaptor.getValue().getOperation(), is("GET /streaming-trace"));
+        assertThat(spanCaptor.getValue().getOperation(), is("Jersey: GET /streaming-trace"));
     }
 
     @Test
@@ -184,7 +184,7 @@ public final class TraceEnrichingFilterTest {
         assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID), is(nullValue()));
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID), is(nullValue()));
         verify(observer).consume(spanCaptor.capture());
-        assertThat(spanCaptor.getValue().getOperation(), is("GET /failing-streaming-trace"));
+        assertThat(spanCaptor.getValue().getOperation(), is("Jersey: GET /failing-streaming-trace"));
     }
 
     @Test
@@ -211,7 +211,7 @@ public final class TraceEnrichingFilterTest {
         assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID), is(nullValue()));
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID), is(nullValue()));
         verify(observer).consume(spanCaptor.capture());
-        assertThat(spanCaptor.getValue().getOperation(), is("GET /trace"));
+        assertThat(spanCaptor.getValue().getOperation(), is("Jersey: GET /trace"));
     }
 
     @Test

--- a/tracing-okhttp3/src/main/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptor.java
+++ b/tracing-okhttp3/src/main/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptor.java
@@ -39,7 +39,7 @@ public enum OkhttpTraceInterceptor implements Interceptor {
         String spanName = request.method();
         String httpRemotingPath = request.header(PATH_TEMPLATE_HEADER);
         if (httpRemotingPath != null) {
-            spanName = httpRemotingPath;
+            spanName = "OkHttp: " + httpRemotingPath;
             request = request.newBuilder().removeHeader(PATH_TEMPLATE_HEADER).build();
         }
 


### PR DESCRIPTION
## Before this PR
Cannot identify whether a span originates from OkHttp or Jersey.

## After this PR
Can identify where a span originates.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->