### PR TITLE
[improvement] Add methods to set span operation when wrapping with a new trace

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -105,51 +105,73 @@ public final class Tracers {
     }
 
     /**
+     * Like {@link #wrapWithNewTrace(String, ExecutorService)}, but with a default initial span operation.
+     */
+    public static ExecutorService wrapWithNewTrace(ExecutorService executorService) {
+        return wrapWithNewTrace(ROOT_SPAN_OPERATION, executorService);
+    }
+
+    /**
      * Wraps the provided executor service to make submitted tasks traceable with a fresh {@link Trace trace}
-     * for each execution, see {@link #wrapWithNewTrace(ExecutorService)}. This method should not be used to
+     * for each execution, see {@link #wrapWithNewTrace(String, ExecutorService)}. This method should not be used to
      * wrap a ScheduledExecutorService that has already been {@link #wrap(ExecutorService) wrapped}. If this is
      * done, a new trace will be generated for each execution, effectively bypassing the intent of the previous
      * wrapping.
      */
-    public static ExecutorService wrapWithNewTrace(ExecutorService executorService) {
+    public static ExecutorService wrapWithNewTrace(String operation, ExecutorService executorService) {
         return new WrappingExecutorService(executorService) {
             @Override
             protected <T> Callable<T> wrapTask(Callable<T> callable) {
-                return wrapWithNewTrace(callable);
+                return wrapWithNewTrace(operation, callable);
             }
         };
     }
 
     /**
-     * Wraps the provided scheduled executor service to make submitted tasks traceable with a fresh {@link Trace trace}
-     * for each execution, see {@link #wrapWithNewTrace(ScheduledExecutorService)}. This method should not be used to
-     * wrap a ScheduledExecutorService that has already been {@link #wrap(ScheduledExecutorService) wrapped}. If this is
-     * done, a new trace will be generated for each execution, effectively bypassing the intent of the previous
-     * wrapping.
+     * Like {@link #wrapWithNewTrace(String, ScheduledExecutorService)}, but with a default initial span operation.
      */
     public static ScheduledExecutorService wrapWithNewTrace(ScheduledExecutorService executorService) {
+        return wrapWithNewTrace(ROOT_SPAN_OPERATION, executorService);
+    }
+
+    /**
+     * Wraps the provided scheduled executor service to make submitted tasks traceable with a fresh {@link Trace trace}
+     * for each execution, see {@link #wrapWithNewTrace(String, ScheduledExecutorService)}. This method should not be
+     * used to wrap a ScheduledExecutorService that has already been {@link #wrap(ScheduledExecutorService) wrapped}.
+     * If this is done, a new trace will be generated for each execution, effectively bypassing the intent of the
+     * previous wrapping.
+     */
+    public static ScheduledExecutorService wrapWithNewTrace(String operation,
+            ScheduledExecutorService executorService) {
         return new WrappingScheduledExecutorService(executorService) {
             @Override
             protected <T> Callable<T> wrapTask(Callable<T> callable) {
-                return wrapWithNewTrace(callable);
+                return wrapWithNewTrace(operation, callable);
             }
         };
+    }
+
+    /**
+     * Like {@link #wrapWithNewTrace(String, Callable)}, but with a default initial span operation.
+     */
+    public static <V> Callable<V> wrapWithNewTrace(Callable<V> delegate) {
+        return wrapWithNewTrace(ROOT_SPAN_OPERATION, delegate);
     }
 
     /**
      * Wraps the given {@link Callable} such that it creates a fresh {@link Trace tracing state} for its execution.
      * That is, the trace during its {@link Callable#call() execution} is entirely separate from the trace at
      * construction or any trace already set on the thread used to execute the callable. Each execution of the callable
-     * will have a fresh trace.
+     * will have a fresh trace. The given {@link String operation} is used to create the initial span.
      */
-    public static <V> Callable<V> wrapWithNewTrace(Callable<V> delegate) {
+    public static <V> Callable<V> wrapWithNewTrace(String operation, Callable<V> delegate) {
         return () -> {
             // clear the existing trace and keep it around for restoration when we're done
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
                 Tracer.initTrace(Optional.empty(), Tracers.randomId());
-                Tracer.startSpan(ROOT_SPAN_OPERATION);
+                Tracer.startSpan(operation);
                 return delegate.call();
             } finally {
                 Tracer.fastCompleteSpan();
@@ -159,16 +181,23 @@ public final class Tracers {
     }
 
     /**
-     * Like {@link #wrapWithNewTrace(Callable)}, but for Runnables.
+     * Like {@link #wrapWithAlternateTraceId(String, Runnable)}, but with a default initial span operation.
      */
     public static Runnable wrapWithNewTrace(Runnable delegate) {
+        return wrapWithNewTrace(ROOT_SPAN_OPERATION, delegate);
+    }
+
+    /**
+     * Like {@link #wrapWithNewTrace(String, Callable)}, but for Runnables.
+     */
+    public static Runnable wrapWithNewTrace(String operation, Runnable delegate) {
         return () -> {
             // clear the existing trace and keep it around for restoration when we're done
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
                 Tracer.initTrace(Optional.empty(), Tracers.randomId());
-                Tracer.startSpan(ROOT_SPAN_OPERATION);
+                Tracer.startSpan(operation);
                 delegate.run();
             } finally {
                 Tracer.fastCompleteSpan();
@@ -178,19 +207,27 @@ public final class Tracers {
     }
 
     /**
+     * Like {@link #wrapWithAlternateTraceId(String, String, Runnable)}, but with a default initial span operation.
+     */
+    public static Runnable wrapWithAlternateTraceId(String traceId, Runnable delegate) {
+        return wrapWithAlternateTraceId(traceId, ROOT_SPAN_OPERATION, delegate);
+    }
+
+    /**
      * Wraps the given {@link Runnable} such that it creates a fresh {@link Trace tracing state with the given traceId}
      * for its execution. That is, the trace during its {@link Runnable#run() execution} will use the traceId provided
      * instead of any trace already set on the thread used to execute the runnable. Each execution of the runnable
-     * will use a new {@link Trace tracing state} with the same given traceId.
+     * will use a new {@link Trace tracing state} with the same given traceId.  The given {@link String operation} is
+     * used to create the initial span.
      */
-    public static Runnable wrapWithAlternateTraceId(String traceId, Runnable delegate) {
+    public static Runnable wrapWithAlternateTraceId(String traceId, String operation, Runnable delegate) {
         return () -> {
             // clear the existing trace and keep it around for restoration when we're done
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
                 Tracer.initTrace(Optional.empty(), traceId);
-                Tracer.startSpan(ROOT_SPAN_OPERATION);
+                Tracer.startSpan(operation);
                 delegate.run();
             } finally {
                 Tracer.fastCompleteSpan();

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -16,6 +16,7 @@
 
 package com.palantir.tracing;
 
+import com.google.errorprone.annotations.CompileTimeConstant;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -116,9 +117,10 @@ public final class Tracers {
      * for each execution, see {@link #wrapWithNewTrace(String, ExecutorService)}. This method should not be used to
      * wrap a ScheduledExecutorService that has already been {@link #wrap(ExecutorService) wrapped}. If this is
      * done, a new trace will be generated for each execution, effectively bypassing the intent of the previous
-     * wrapping.
+     * wrapping.  The given {@link String operation} is used to create the initial span.
      */
-    public static ExecutorService wrapWithNewTrace(String operation, ExecutorService executorService) {
+    public static ExecutorService wrapWithNewTrace(@CompileTimeConstant String operation,
+            ExecutorService executorService) {
         return new WrappingExecutorService(executorService) {
             @Override
             protected <T> Callable<T> wrapTask(Callable<T> callable) {
@@ -139,9 +141,9 @@ public final class Tracers {
      * for each execution, see {@link #wrapWithNewTrace(String, ScheduledExecutorService)}. This method should not be
      * used to wrap a ScheduledExecutorService that has already been {@link #wrap(ScheduledExecutorService) wrapped}.
      * If this is done, a new trace will be generated for each execution, effectively bypassing the intent of the
-     * previous wrapping.
+     * previous wrapping.  The given {@link String operation} is used to create the initial span.
      */
-    public static ScheduledExecutorService wrapWithNewTrace(String operation,
+    public static ScheduledExecutorService wrapWithNewTrace(@CompileTimeConstant String operation,
             ScheduledExecutorService executorService) {
         return new WrappingScheduledExecutorService(executorService) {
             @Override
@@ -164,7 +166,7 @@ public final class Tracers {
      * construction or any trace already set on the thread used to execute the callable. Each execution of the callable
      * will have a fresh trace. The given {@link String operation} is used to create the initial span.
      */
-    public static <V> Callable<V> wrapWithNewTrace(String operation, Callable<V> delegate) {
+    public static <V> Callable<V> wrapWithNewTrace(@CompileTimeConstant String operation, Callable<V> delegate) {
         return () -> {
             // clear the existing trace and keep it around for restoration when we're done
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
@@ -190,7 +192,7 @@ public final class Tracers {
     /**
      * Like {@link #wrapWithNewTrace(String, Callable)}, but for Runnables.
      */
-    public static Runnable wrapWithNewTrace(String operation, Runnable delegate) {
+    public static Runnable wrapWithNewTrace(@CompileTimeConstant String operation, Runnable delegate) {
         return () -> {
             // clear the existing trace and keep it around for restoration when we're done
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
@@ -220,7 +222,8 @@ public final class Tracers {
      * will use a new {@link Trace tracing state} with the same given traceId.  The given {@link String operation} is
      * used to create the initial span.
      */
-    public static Runnable wrapWithAlternateTraceId(String traceId, String operation, Runnable delegate) {
+    public static Runnable wrapWithAlternateTraceId(String traceId, @CompileTimeConstant String operation, Runnable
+            delegate) {
         return () -> {
             // clear the existing trace and keep it around for restoration when we're done
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -95,12 +95,12 @@ public final class TracersTest {
 
     @Test
     public void testScheduledExecutorServiceWrapsCallablesWithNewTraces() throws Exception {
-        String someOperartion = "operationToUse";
+        String someOperation = "operationToUse";
         ScheduledExecutorService wrappedService =
-                Tracers.wrapWithNewTrace(someOperartion, Executors.newSingleThreadScheduledExecutor());
+                Tracers.wrapWithNewTrace(someOperation, Executors.newSingleThreadScheduledExecutor());
 
-        Callable<Void> callable = newTraceExpectingCallable(someOperartion);
-        Runnable runnable = newTraceExpectingRunnable(someOperartion);
+        Callable<Void> callable = newTraceExpectingCallable(someOperation);
+        Runnable runnable = newTraceExpectingRunnable(someOperation);
 
         // Empty trace
         wrappedService.schedule(callable, 0, TimeUnit.SECONDS).get();
@@ -122,12 +122,12 @@ public final class TracersTest {
 
     @Test
     public void testExecutorServiceWrapsCallablesWithNewTraces() throws Exception {
-        String someOperartion = "operationToUse";
+        String someOperation = "operationToUse";
         ExecutorService wrappedService =
-                Tracers.wrapWithNewTrace(someOperartion, Executors.newSingleThreadExecutor());
+                Tracers.wrapWithNewTrace(someOperation, Executors.newSingleThreadExecutor());
 
-        Callable<Void> callable = newTraceExpectingCallable(someOperartion);
-        Runnable runnable = newTraceExpectingRunnable(someOperartion);
+        Callable<Void> callable = newTraceExpectingCallable(someOperation);
+        Runnable runnable = newTraceExpectingRunnable(someOperation);
 
         // Empty trace
         wrappedService.submit(callable).get();

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -229,6 +229,22 @@ public final class TracersTest {
 
     @Test
     public void testWrapCallableWithNewTrace_traceStateInsideCallableHasSpan() throws Exception {
+        Callable<List<OpenSpan>> wrappedCallable = Tracers.wrapWithNewTrace(() -> {
+            return getCurrentFullTrace();
+        });
+
+        List<OpenSpan> spans = wrappedCallable.call();
+
+        assertThat(spans).hasSize(1);
+
+        OpenSpan span = spans.get(0);
+
+        assertThat(span.getOperation()).isEqualTo("root");
+        assertThat(span.getParentSpanId()).isEmpty();
+    }
+
+    @Test
+    public void testWrapCallableWithNewTrace_traceStateInsideCallableHasGivenSpan() throws Exception {
         String operationToUse = "someOperation";
         Callable<List<OpenSpan>> wrappedCallable = Tracers.wrapWithNewTrace(operationToUse, () -> {
             return getCurrentFullTrace();
@@ -300,6 +316,24 @@ public final class TracersTest {
     public void testWrapRunnableWithNewTrace_traceStateInsideRunnableHasSpan() throws Exception {
         List<List<OpenSpan>> spans = Lists.newArrayList();
 
+        Runnable wrappedRunnable = Tracers.wrapWithNewTrace(() -> {
+            spans.add(getCurrentFullTrace());
+        });
+
+        wrappedRunnable.run();
+
+        assertThat(spans.get(0)).hasSize(1);
+
+        OpenSpan span = spans.get(0).get(0);
+
+        assertThat(span.getOperation()).isEqualTo("root");
+        assertThat(span.getParentSpanId()).isEmpty();
+    }
+
+    @Test
+    public void testWrapRunnableWithNewTrace_traceStateInsideRunnableHasGivenSpan() throws Exception {
+        List<List<OpenSpan>> spans = Lists.newArrayList();
+
         String operationToUse = "someOperation";
         Runnable wrappedRunnable = Tracers.wrapWithNewTrace(operationToUse, () -> {
             spans.add(getCurrentFullTrace());
@@ -362,6 +396,25 @@ public final class TracersTest {
 
     @Test
     public void testWrapRunnableWithAlternateTraceId_traceStateInsideRunnableHasSpan() {
+        List<List<OpenSpan>> spans = Lists.newArrayList();
+
+        String traceIdToUse = "someTraceId";
+        Runnable wrappedRunnable = Tracers.wrapWithAlternateTraceId(traceIdToUse, () -> {
+            spans.add(getCurrentFullTrace());
+        });
+
+        wrappedRunnable.run();
+
+        assertThat(spans.get(0)).hasSize(1);
+
+        OpenSpan span = spans.get(0).get(0);
+
+        assertThat(span.getOperation()).isEqualTo("root");
+        assertThat(span.getParentSpanId()).isEmpty();
+    }
+
+    @Test
+    public void testWrapRunnableWithAlternateTraceId_traceStateInsideRunnableHasGivenSpan() {
         List<List<OpenSpan>> spans = Lists.newArrayList();
 
         String traceIdToUse = "someTraceId";

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -95,12 +95,11 @@ public final class TracersTest {
 
     @Test
     public void testScheduledExecutorServiceWrapsCallablesWithNewTraces() throws Exception {
-        String someOperation = "operationToUse";
         ScheduledExecutorService wrappedService =
-                Tracers.wrapWithNewTrace(someOperation, Executors.newSingleThreadScheduledExecutor());
+                Tracers.wrapWithNewTrace("operationToUse", Executors.newSingleThreadScheduledExecutor());
 
-        Callable<Void> callable = newTraceExpectingCallable(someOperation);
-        Runnable runnable = newTraceExpectingRunnable(someOperation);
+        Callable<Void> callable = newTraceExpectingCallable("operationToUse");
+        Runnable runnable = newTraceExpectingRunnable("operationToUse");
 
         // Empty trace
         wrappedService.schedule(callable, 0, TimeUnit.SECONDS).get();
@@ -122,12 +121,11 @@ public final class TracersTest {
 
     @Test
     public void testExecutorServiceWrapsCallablesWithNewTraces() throws Exception {
-        String someOperation = "operationToUse";
         ExecutorService wrappedService =
-                Tracers.wrapWithNewTrace(someOperation, Executors.newSingleThreadExecutor());
+                Tracers.wrapWithNewTrace("operationToUse", Executors.newSingleThreadExecutor());
 
-        Callable<Void> callable = newTraceExpectingCallable(someOperation);
-        Runnable runnable = newTraceExpectingRunnable(someOperation);
+        Callable<Void> callable = newTraceExpectingCallable("operationToUse");
+        Runnable runnable = newTraceExpectingRunnable("operationToUse");
 
         // Empty trace
         wrappedService.submit(callable).get();
@@ -245,8 +243,7 @@ public final class TracersTest {
 
     @Test
     public void testWrapCallableWithNewTrace_traceStateInsideCallableHasGivenSpan() throws Exception {
-        String operationToUse = "someOperation";
-        Callable<List<OpenSpan>> wrappedCallable = Tracers.wrapWithNewTrace(operationToUse, () -> {
+        Callable<List<OpenSpan>> wrappedCallable = Tracers.wrapWithNewTrace("someOperation", () -> {
             return getCurrentFullTrace();
         });
 
@@ -256,7 +253,7 @@ public final class TracersTest {
 
         OpenSpan span = spans.get(0);
 
-        assertThat(span.getOperation()).isEqualTo(operationToUse);
+        assertThat(span.getOperation()).isEqualTo("someOperation");
         assertThat(span.getParentSpanId()).isEmpty();
     }
 
@@ -334,8 +331,7 @@ public final class TracersTest {
     public void testWrapRunnableWithNewTrace_traceStateInsideRunnableHasGivenSpan() throws Exception {
         List<List<OpenSpan>> spans = Lists.newArrayList();
 
-        String operationToUse = "someOperation";
-        Runnable wrappedRunnable = Tracers.wrapWithNewTrace(operationToUse, () -> {
+        Runnable wrappedRunnable = Tracers.wrapWithNewTrace("someOperation", () -> {
             spans.add(getCurrentFullTrace());
         });
 
@@ -345,7 +341,7 @@ public final class TracersTest {
 
         OpenSpan span = spans.get(0).get(0);
 
-        assertThat(span.getOperation()).isEqualTo(operationToUse);
+        assertThat(span.getOperation()).isEqualTo("someOperation");
         assertThat(span.getParentSpanId()).isEmpty();
     }
 
@@ -418,8 +414,7 @@ public final class TracersTest {
         List<List<OpenSpan>> spans = Lists.newArrayList();
 
         String traceIdToUse = "someTraceId";
-        String operationToUse = "someOperation";
-        Runnable wrappedRunnable = Tracers.wrapWithAlternateTraceId(traceIdToUse, operationToUse, () -> {
+        Runnable wrappedRunnable = Tracers.wrapWithAlternateTraceId(traceIdToUse, "someOperation", () -> {
             spans.add(getCurrentFullTrace());
         });
 
@@ -429,7 +424,7 @@ public final class TracersTest {
 
         OpenSpan span = spans.get(0).get(0);
 
-        assertThat(span.getOperation()).isEqualTo(operationToUse);
+        assertThat(span.getOperation()).isEqualTo("someOperation");
         assertThat(span.getParentSpanId()).isEmpty();
     }
 


### PR DESCRIPTION
## Before this PR
When calling any of the `wrapWithNewTrace` methods, the operation of the initial span would be set to "root". This makes it difficult to determine the origin of traces if `wrapWithNewTrace` is used in more than one place.

## After this PR
`Tracers` now provides variants of the `wrapWithNewTrace` methods that allow callers to explicitly set the initial span operation.

Follow up to #49.
