### PR TITLE
Add methods to create wrapped executor with new span

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
@@ -16,7 +16,6 @@
 
 package com.palantir.tracing;
 
-import com.google.errorprone.annotations.CompileTimeConstant;
 import java.util.Optional;
 
 /**
@@ -46,7 +45,7 @@ public final class DeferredTracer {
         this(Optional.empty());
     }
 
-    public DeferredTracer(@CompileTimeConstant String operation) {
+    public DeferredTracer(String operation) {
         this(Optional.of(operation));
     }
 

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -26,7 +26,8 @@ import java.util.concurrent.ThreadLocalRandom;
 public final class Tracers {
     /** The key under which trace ids are inserted into SLF4J {@link org.slf4j.MDC MDCs}. */
     public static final String TRACE_ID_KEY = "traceId";
-    private static final String ROOT_SPAN_OPERATION = "root";
+    private static final String DEFAULT_ROOT_SPAN_OPERATION = "root";
+    private static final String DEFAULT_EXECUTOR_SPAN_OPERATION = "executor";
     private static final char[] HEX_DIGITS =
             {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
@@ -68,12 +69,7 @@ public final class Tracers {
      * #wrap wrapped} in order to be trace-aware.
      */
     public static ExecutorService wrap(ExecutorService executorService) {
-        return new WrappingExecutorService(executorService) {
-            @Override
-            protected <T> Callable<T> wrapTask(Callable<T> callable) {
-                return wrap(callable);
-            }
-        };
+        return wrap(DEFAULT_EXECUTOR_SPAN_OPERATION, executorService);
     }
 
     /**
@@ -96,12 +92,7 @@ public final class Tracers {
      * trace will be generated for each execution, effectively bypassing the intent of this method.
      */
     public static ScheduledExecutorService wrap(ScheduledExecutorService executorService) {
-        return new WrappingScheduledExecutorService(executorService) {
-            @Override
-            protected <T> Callable<T> wrapTask(Callable<T> callable) {
-                return wrap(callable);
-            }
-        };
+        return wrap(DEFAULT_EXECUTOR_SPAN_OPERATION, executorService);
     }
 
     /**
@@ -157,7 +148,7 @@ public final class Tracers {
      */
     @Deprecated
     public static ExecutorService wrapWithNewTrace(ExecutorService executorService) {
-        return wrapWithNewTrace(ROOT_SPAN_OPERATION, executorService);
+        return wrapWithNewTrace(DEFAULT_ROOT_SPAN_OPERATION, executorService);
     }
 
     /**
@@ -183,7 +174,7 @@ public final class Tracers {
      */
     @Deprecated
     public static ScheduledExecutorService wrapWithNewTrace(ScheduledExecutorService executorService) {
-        return wrapWithNewTrace(ROOT_SPAN_OPERATION, executorService);
+        return wrapWithNewTrace(DEFAULT_ROOT_SPAN_OPERATION, executorService);
     }
 
     /**
@@ -210,7 +201,7 @@ public final class Tracers {
      */
     @Deprecated
     public static <V> Callable<V> wrapWithNewTrace(Callable<V> delegate) {
-        return wrapWithNewTrace(ROOT_SPAN_OPERATION, delegate);
+        return wrapWithNewTrace(DEFAULT_ROOT_SPAN_OPERATION, delegate);
     }
 
     /**
@@ -242,7 +233,7 @@ public final class Tracers {
      */
     @Deprecated
     public static Runnable wrapWithNewTrace(Runnable delegate) {
-        return wrapWithNewTrace(ROOT_SPAN_OPERATION, delegate);
+        return wrapWithNewTrace(DEFAULT_ROOT_SPAN_OPERATION, delegate);
     }
 
     /**
@@ -274,7 +265,7 @@ public final class Tracers {
      */
     @Deprecated
     public static Runnable wrapWithAlternateTraceId(String traceId, Runnable delegate) {
-        return wrapWithAlternateTraceId(traceId, ROOT_SPAN_OPERATION, delegate);
+        return wrapWithAlternateTraceId(traceId, DEFAULT_ROOT_SPAN_OPERATION, delegate);
     }
 
     /**

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -80,7 +80,7 @@ public final class Tracers {
      * Like {@link #wrap(ExecutorService)}, but using the given {@link String operation} is used to create a span for
      * submitted tasks.
      */
-    public static ExecutorService wrap(@CompileTimeConstant String operation, ExecutorService executorService) {
+    public static ExecutorService wrap(String operation, ExecutorService executorService) {
         return new WrappingExecutorService(executorService) {
             @Override
             protected <T> Callable<T> wrapTask(Callable<T> callable) {
@@ -108,7 +108,7 @@ public final class Tracers {
      * Like {@link #wrap(ScheduledExecutorService)}, but using the given {@link String operation} is used to create a
      * span for submitted tasks.
      */
-    public static ScheduledExecutorService wrap(@CompileTimeConstant String operation,
+    public static ScheduledExecutorService wrap(String operation,
             ScheduledExecutorService executorService) {
         return new WrappingScheduledExecutorService(executorService) {
             @Override
@@ -130,7 +130,7 @@ public final class Tracers {
      * Like {@link #wrap(Callable)}, but using the given {@link String operation} is used to create a span for the
      * execution.
      */
-    public static <V> Callable<V> wrap(@CompileTimeConstant String operation, Callable<V> delegate) {
+    public static <V> Callable<V> wrap(String operation, Callable<V> delegate) {
         return new TracingAwareCallable<>(Optional.of(operation), delegate);
     }
 
@@ -146,7 +146,7 @@ public final class Tracers {
      * Like {@link #wrap(Runnable)}, but using the given {@link String operation} is used to create a span for the
      * execution.
      */
-    public static Runnable wrap(@CompileTimeConstant String operation, Runnable delegate) {
+    public static Runnable wrap(String operation, Runnable delegate) {
         return new TracingAwareRunnable(Optional.of(operation), delegate);
     }
 

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -61,15 +61,15 @@ public final class TracersTest {
                 Tracers.wrap(Executors.newSingleThreadExecutor());
 
         // Empty trace
-        wrappedService.submit(traceExpectingCallable()).get();
-        wrappedService.submit(traceExpectingRunnable()).get();
+        wrappedService.submit(traceExpectingCallableWithSpan("executor")).get();
+        wrappedService.submit(traceExpectingRunnableWithSpan("executor")).get();
 
         // Non-empty trace
         Tracer.startSpan("foo");
         Tracer.startSpan("bar");
         Tracer.startSpan("baz");
-        wrappedService.submit(traceExpectingCallable()).get();
-        wrappedService.submit(traceExpectingRunnable()).get();
+        wrappedService.submit(traceExpectingCallableWithSpan("executor")).get();
+        wrappedService.submit(traceExpectingRunnableWithSpan("executor")).get();
         Tracer.completeSpan();
         Tracer.completeSpan();
         Tracer.completeSpan();
@@ -101,15 +101,15 @@ public final class TracersTest {
                 Tracers.wrap(Executors.newSingleThreadScheduledExecutor());
 
         // Empty trace
-        wrappedService.schedule(traceExpectingCallable(), 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(traceExpectingRunnable(), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingCallableWithSpan("executor"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingRunnableWithSpan("executor"), 0, TimeUnit.SECONDS).get();
 
         // Non-empty trace
         Tracer.startSpan("foo");
         Tracer.startSpan("bar");
         Tracer.startSpan("baz");
-        wrappedService.schedule(traceExpectingCallable(), 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(traceExpectingRunnable(), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingCallableWithSpan("executor"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingRunnableWithSpan("executor"), 0, TimeUnit.SECONDS).get();
         Tracer.completeSpan();
         Tracer.completeSpan();
         Tracer.completeSpan();

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -190,11 +190,11 @@ public final class TracersTest {
     @Test
     public void testWrapCallable_callableTraceIsIsolated() throws Exception {
         Tracer.startSpan("outside");
-        Callable<Void> runnable = Tracers.wrap(() -> {
+        Callable<Void> callable = Tracers.wrap(() -> {
             Tracer.startSpan("inside"); // never completed
             return null;
         });
-        runnable.call();
+        callable.call();
         assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("outside");
     }
 

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -56,76 +56,118 @@ public final class TracersTest {
     }
 
     @Test
-    public void testExecutorServiceWrapsCallables() throws Exception {
-        ExecutorService wrappedService = Tracers.wrap(Executors.newSingleThreadExecutor());
-
-        // Empty trace
-        wrappedService.submit(traceExpectingCallable()).get();
-        wrappedService.submit(traceExpectingRunnable()).get();
-
-        // Non-empty trace
-        Tracer.startSpan("foo");
-        Tracer.startSpan("bar");
-        Tracer.startSpan("baz");
-        wrappedService.submit(traceExpectingCallable()).get();
-        wrappedService.submit(traceExpectingRunnable()).get();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
-    }
-
-    @Test
-    public void testScheduledExecutorServiceWrapsCallables() throws Exception {
-        ScheduledExecutorService wrappedService = Tracers.wrap(Executors.newSingleThreadScheduledExecutor());
-
-        // Empty trace
-        wrappedService.schedule(traceExpectingCallable(), 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(traceExpectingRunnable(), 0, TimeUnit.SECONDS).get();
-
-        // Non-empty trace
-        Tracer.startSpan("foo");
-        Tracer.startSpan("bar");
-        Tracer.startSpan("baz");
-        wrappedService.schedule(traceExpectingCallable(), 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(traceExpectingRunnable(), 0, TimeUnit.SECONDS).get();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
-    }
-
-    @Test
-    public void testScheduledExecutorServiceWrapsCallablesWithNewTraces() throws Exception {
-        ScheduledExecutorService wrappedService =
-                Tracers.wrapWithNewTrace("operationToUse", Executors.newSingleThreadScheduledExecutor());
-
-        Callable<Void> callable = newTraceExpectingCallable("operationToUse");
-        Runnable runnable = newTraceExpectingRunnable("operationToUse");
-
-        // Empty trace
-        wrappedService.schedule(callable, 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(runnable, 0, TimeUnit.SECONDS).get();
-
-        wrappedService.schedule(callable, 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(runnable, 0, TimeUnit.SECONDS).get();
-
-        // Non-empty trace
-        Tracer.startSpan("foo");
-        Tracer.startSpan("bar");
-        Tracer.startSpan("baz");
-        wrappedService.schedule(callable, 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(runnable, 0, TimeUnit.SECONDS).get();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
-    }
-
-    @Test
-    public void testExecutorServiceWrapsCallablesWithNewTraces() throws Exception {
+    public void testWrapExecutorService() throws Exception {
         ExecutorService wrappedService =
-                Tracers.wrapWithNewTrace("operationToUse", Executors.newSingleThreadExecutor());
+                Tracers.wrap(Executors.newSingleThreadExecutor());
 
-        Callable<Void> callable = newTraceExpectingCallable("operationToUse");
-        Runnable runnable = newTraceExpectingRunnable("operationToUse");
+        // Empty trace
+        wrappedService.submit(traceExpectingCallable()).get();
+        wrappedService.submit(traceExpectingRunnable()).get();
+
+        // Non-empty trace
+        Tracer.startSpan("foo");
+        Tracer.startSpan("bar");
+        Tracer.startSpan("baz");
+        wrappedService.submit(traceExpectingCallable()).get();
+        wrappedService.submit(traceExpectingRunnable()).get();
+        Tracer.completeSpan();
+        Tracer.completeSpan();
+        Tracer.completeSpan();
+    }
+
+    @Test
+    public void testWrapExecutorService_withSpan() throws Exception {
+        ExecutorService wrappedService =
+                Tracers.wrap("operation", Executors.newSingleThreadExecutor());
+
+        // Empty trace
+        wrappedService.submit(traceExpectingCallableWithSpan("operation")).get();
+        wrappedService.submit(traceExpectingRunnableWithSpan("operation")).get();
+
+        // Non-empty trace
+        Tracer.startSpan("foo");
+        Tracer.startSpan("bar");
+        Tracer.startSpan("baz");
+        wrappedService.submit(traceExpectingCallableWithSpan("operation")).get();
+        wrappedService.submit(traceExpectingRunnableWithSpan("operation")).get();
+        Tracer.completeSpan();
+        Tracer.completeSpan();
+        Tracer.completeSpan();
+    }
+
+    @Test
+    public void testWrapScheduledExecutorService() throws Exception {
+        ScheduledExecutorService wrappedService =
+                Tracers.wrap(Executors.newSingleThreadScheduledExecutor());
+
+        // Empty trace
+        wrappedService.schedule(traceExpectingCallable(), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingRunnable(), 0, TimeUnit.SECONDS).get();
+
+        // Non-empty trace
+        Tracer.startSpan("foo");
+        Tracer.startSpan("bar");
+        Tracer.startSpan("baz");
+        wrappedService.schedule(traceExpectingCallable(), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingRunnable(), 0, TimeUnit.SECONDS).get();
+        Tracer.completeSpan();
+        Tracer.completeSpan();
+        Tracer.completeSpan();
+    }
+
+    @Test
+    public void testWrapScheduledExecutorService_withSpan() throws Exception {
+        ScheduledExecutorService wrappedService =
+                Tracers.wrap("operation", Executors.newSingleThreadScheduledExecutor());
+
+        // Empty trace
+        wrappedService.schedule(traceExpectingCallableWithSpan("operation"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingRunnableWithSpan("operation"), 0, TimeUnit.SECONDS).get();
+
+        // Non-empty trace
+        Tracer.startSpan("foo");
+        Tracer.startSpan("bar");
+        Tracer.startSpan("baz");
+        wrappedService.schedule(traceExpectingCallableWithSpan("operation"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingRunnableWithSpan("operation"), 0, TimeUnit.SECONDS).get();
+        Tracer.completeSpan();
+        Tracer.completeSpan();
+        Tracer.completeSpan();
+    }
+
+    @Test
+    public void testWrapScheduledExecutorServiceWithNewTrace() throws Exception {
+        ScheduledExecutorService wrappedService =
+                Tracers.wrapWithNewTrace("operation", Executors.newSingleThreadScheduledExecutor());
+
+        Callable<Void> callable = newTraceExpectingCallable("operation");
+        Runnable runnable = newTraceExpectingRunnable("operation");
+
+        // Empty trace
+        wrappedService.schedule(callable, 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(runnable, 0, TimeUnit.SECONDS).get();
+
+        wrappedService.schedule(callable, 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(runnable, 0, TimeUnit.SECONDS).get();
+
+        // Non-empty trace
+        Tracer.startSpan("foo");
+        Tracer.startSpan("bar");
+        Tracer.startSpan("baz");
+        wrappedService.schedule(callable, 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(runnable, 0, TimeUnit.SECONDS).get();
+        Tracer.completeSpan();
+        Tracer.completeSpan();
+        Tracer.completeSpan();
+    }
+
+    @Test
+    public void testWrapExecutorServiceWithNewTrace() throws Exception {
+        ExecutorService wrappedService =
+                Tracers.wrapWithNewTrace("operation", Executors.newSingleThreadExecutor());
+
+        Callable<Void> callable = newTraceExpectingCallable("operation");
+        Runnable runnable = newTraceExpectingRunnable("operation");
 
         // Empty trace
         wrappedService.submit(callable).get();
@@ -146,57 +188,65 @@ public final class TracersTest {
     }
 
     @Test
-    public void testWrappingRunnable_runnableTraceIsIsolated() throws Exception {
+    public void testWrapRunnable_runnableTraceIsIsolated() throws Exception {
         Tracer.startSpan("outside");
-        Runnable runnable = Tracers.wrap(new Runnable() {
-            @Override
-            public void run() {
-                Tracer.startSpan("inside"); // never completed
-            }
+        Runnable runnable = Tracers.wrap(() -> {
+            Tracer.startSpan("inside"); // never completed
         });
         runnable.run();
         assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("outside");
     }
 
     @Test
-    public void testWrappingRunnable_traceStateIsCapturedAtConstructionTime() throws Exception {
+    public void testWrapRunnable_traceStateIsCapturedAtConstructionTime() throws Exception {
         Tracer.startSpan("before-construction");
-        Runnable runnable = Tracers.wrap(new Runnable() {
-            @Override
-            public void run() {
-                assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("before-construction");
-            }
+        Runnable runnable = Tracers.wrap(() -> {
+            assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("before-construction");
         });
         Tracer.startSpan("after-construction");
         runnable.run();
     }
 
     @Test
-    public void testWrappingCallable_callableTraceIsIsolated() throws Exception {
+    public void testWrapRunnable_startsNewSpan() throws Exception {
         Tracer.startSpan("outside");
-        Callable<Void> runnable = Tracers.wrap(new Callable<Void>() {
-            @Override
-            public Void call() {
-                Tracer.startSpan("inside"); // never completed
-                return null;
-            }
+        Runnable runnable = Tracers.wrap("operation", () -> {
+            assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("operation");
+        });
+        runnable.run();
+        assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("outside");
+    }
+
+    @Test
+    public void testWrapCallable_callableTraceIsIsolated() throws Exception {
+        Tracer.startSpan("outside");
+        Callable<Void> runnable = Tracers.wrap(() -> {
+            Tracer.startSpan("inside"); // never completed
+            return null;
         });
         runnable.call();
         assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("outside");
     }
 
     @Test
-    public void testWrappingCallable_traceStateIsCapturedAtConstructionTime() throws Exception {
+    public void testWrapCallable_traceStateIsCapturedAtConstructionTime() throws Exception {
         Tracer.startSpan("before-construction");
-        Callable<Void> callable = Tracers.wrap(new Callable<Void>() {
-            @Override
-            public Void call() {
-                assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("before-construction");
-                return null;
-            }
+        Callable<Void> callable = Tracers.wrap(() -> {
+            assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("before-construction");
+            return null;
         });
         Tracer.startSpan("after-construction");
         callable.call();
+    }
+
+    @Test
+    public void testWrapCallable_withSpan() throws Exception {
+        Tracer.startSpan("outside");
+        Runnable runnable = Tracers.wrap("operation", () -> {
+            assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("operation");
+        });
+        runnable.run();
+        assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("outside");
     }
 
     @Test
@@ -228,7 +278,7 @@ public final class TracersTest {
     @Test
     public void testWrapCallableWithNewTrace_traceStateInsideCallableHasSpan() throws Exception {
         Callable<List<OpenSpan>> wrappedCallable = Tracers.wrapWithNewTrace(() -> {
-            return getCurrentFullTrace();
+            return getCurrentTrace();
         });
 
         List<OpenSpan> spans = wrappedCallable.call();
@@ -243,8 +293,8 @@ public final class TracersTest {
 
     @Test
     public void testWrapCallableWithNewTrace_traceStateInsideCallableHasGivenSpan() throws Exception {
-        Callable<List<OpenSpan>> wrappedCallable = Tracers.wrapWithNewTrace("someOperation", () -> {
-            return getCurrentFullTrace();
+        Callable<List<OpenSpan>> wrappedCallable = Tracers.wrapWithNewTrace("operation", () -> {
+            return getCurrentTrace();
         });
 
         List<OpenSpan> spans = wrappedCallable.call();
@@ -253,7 +303,7 @@ public final class TracersTest {
 
         OpenSpan span = spans.get(0);
 
-        assertThat(span.getOperation()).isEqualTo("someOperation");
+        assertThat(span.getOperation()).isEqualTo("operation");
         assertThat(span.getParentSpanId()).isEmpty();
     }
 
@@ -314,7 +364,7 @@ public final class TracersTest {
         List<List<OpenSpan>> spans = Lists.newArrayList();
 
         Runnable wrappedRunnable = Tracers.wrapWithNewTrace(() -> {
-            spans.add(getCurrentFullTrace());
+            spans.add(getCurrentTrace());
         });
 
         wrappedRunnable.run();
@@ -331,8 +381,8 @@ public final class TracersTest {
     public void testWrapRunnableWithNewTrace_traceStateInsideRunnableHasGivenSpan() throws Exception {
         List<List<OpenSpan>> spans = Lists.newArrayList();
 
-        Runnable wrappedRunnable = Tracers.wrapWithNewTrace("someOperation", () -> {
-            spans.add(getCurrentFullTrace());
+        Runnable wrappedRunnable = Tracers.wrapWithNewTrace("operation", () -> {
+            spans.add(getCurrentTrace());
         });
 
         wrappedRunnable.run();
@@ -341,7 +391,7 @@ public final class TracersTest {
 
         OpenSpan span = spans.get(0).get(0);
 
-        assertThat(span.getOperation()).isEqualTo("someOperation");
+        assertThat(span.getOperation()).isEqualTo("operation");
         assertThat(span.getParentSpanId()).isEmpty();
     }
 
@@ -396,7 +446,7 @@ public final class TracersTest {
 
         String traceIdToUse = "someTraceId";
         Runnable wrappedRunnable = Tracers.wrapWithAlternateTraceId(traceIdToUse, () -> {
-            spans.add(getCurrentFullTrace());
+            spans.add(getCurrentTrace());
         });
 
         wrappedRunnable.run();
@@ -414,8 +464,8 @@ public final class TracersTest {
         List<List<OpenSpan>> spans = Lists.newArrayList();
 
         String traceIdToUse = "someTraceId";
-        Runnable wrappedRunnable = Tracers.wrapWithAlternateTraceId(traceIdToUse, "someOperation", () -> {
-            spans.add(getCurrentFullTrace());
+        Runnable wrappedRunnable = Tracers.wrapWithAlternateTraceId(traceIdToUse, "operation", () -> {
+            spans.add(getCurrentTrace());
         });
 
         wrappedRunnable.run();
@@ -424,7 +474,7 @@ public final class TracersTest {
 
         OpenSpan span = spans.get(0).get(0);
 
-        assertThat(span.getOperation()).isEqualTo("someOperation");
+        assertThat(span.getOperation()).isEqualTo("operation");
         assertThat(span.getParentSpanId()).isEmpty();
     }
 
@@ -463,20 +513,17 @@ public final class TracersTest {
         final Set<String> seenTraceIds = new HashSet<>();
         seenTraceIds.add(Tracer.getTraceId());
 
-        return new Callable<Void>() {
-            @Override
-            public Void call() throws Exception {
-                String newTraceId = Tracer.getTraceId();
-                List<OpenSpan> spans = getCurrentFullTrace();
+        return () -> {
+            String newTraceId = Tracer.getTraceId();
+            List<OpenSpan> spans = getCurrentTrace();
 
-                assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(newTraceId);
-                assertThat(seenTraceIds).doesNotContain(newTraceId);
-                assertThat(spans).hasSize(1);
-                assertThat(spans.get(0).getOperation()).isEqualTo(expectedOperation);
-                assertThat(spans.get(0).getParentSpanId()).isEmpty();
-                seenTraceIds.add(newTraceId);
-                return null;
-            }
+            assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(newTraceId);
+            assertThat(seenTraceIds).doesNotContain(newTraceId);
+            assertThat(spans).hasSize(1);
+            assertThat(spans.get(0).getOperation()).isEqualTo(expectedOperation);
+            assertThat(spans.get(0).getParentSpanId()).isEmpty();
+            seenTraceIds.add(newTraceId);
+            return null;
         };
     }
 
@@ -484,56 +531,88 @@ public final class TracersTest {
         final Set<String> seenTraceIds = new HashSet<>();
         seenTraceIds.add(Tracer.getTraceId());
 
-        return new Runnable() {
-            @Override
-            public void run() {
-                String newTraceId = Tracer.getTraceId();
-                List<OpenSpan> spans = getCurrentFullTrace();
+        return () -> {
+            String newTraceId = Tracer.getTraceId();
+            List<OpenSpan> spans = getCurrentTrace();
 
-                assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(newTraceId);
-                assertThat(seenTraceIds).doesNotContain(newTraceId);
-                assertThat(spans).hasSize(1);
-                assertThat(spans.get(0).getOperation()).isEqualTo(expectedOperation);
-                assertThat(spans.get(0).getParentSpanId()).isEmpty();
-                seenTraceIds.add(newTraceId);
-            }
+            assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(newTraceId);
+            assertThat(seenTraceIds).doesNotContain(newTraceId);
+            assertThat(spans).hasSize(1);
+            assertThat(spans.get(0).getOperation()).isEqualTo(expectedOperation);
+            assertThat(spans.get(0).getParentSpanId()).isEmpty();
+            seenTraceIds.add(newTraceId);
         };
     }
 
     private static Callable<Void> traceExpectingCallable() {
-        final String expectedTraceId = Tracer.getTraceId();
-        final List<OpenSpan> expectedTrace = getCurrentFullTrace();
-        return new Callable<Void>() {
-            @Override
-            public Void call() throws Exception {
-                assertThat(Tracer.getTraceId()).isEqualTo(expectedTraceId);
-                assertThat(getCurrentFullTrace()).isEqualTo(expectedTrace);
-                assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(expectedTraceId);
-                return null;
-            }
+        final String outsideTraceId = Tracer.getTraceId();
+        final List<OpenSpan> outsideTrace = getCurrentTrace();
+
+        return () -> {
+            String traceId = Tracer.getTraceId();
+            List<OpenSpan> trace = getCurrentTrace();
+
+            assertThat(traceId).isEqualTo(outsideTraceId);
+            assertThat(trace).isEqualTo(outsideTrace);
+            assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(outsideTraceId);
+            return null;
         };
     }
 
     private static Runnable traceExpectingRunnable() {
-        final String expectedTraceId = Tracer.getTraceId();
-        final List<OpenSpan> expectedTrace = getCurrentFullTrace();
-        return new Runnable() {
-            @Override
-            public void run() {
-                assertThat(Tracer.getTraceId()).isEqualTo(expectedTraceId);
-                assertThat(getCurrentFullTrace()).isEqualTo(expectedTrace);
-                assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(expectedTraceId);
-            }
+        final String outsideTraceId = Tracer.getTraceId();
+        final List<OpenSpan> outsideTrace = getCurrentTrace();
+
+        return () -> {
+            String traceId = Tracer.getTraceId();
+            List<OpenSpan> trace = getCurrentTrace();
+
+            assertThat(traceId).isEqualTo(outsideTraceId);
+            assertThat(trace).isEqualTo(outsideTrace);
+            assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(outsideTraceId);
         };
     }
 
-    private static List<OpenSpan> getCurrentFullTrace() {
+    private static Callable<Void> traceExpectingCallableWithSpan(String operation) {
+        final String outsideTraceId = Tracer.getTraceId();
+        final List<OpenSpan> outsideTrace = getCurrentTrace();
+
+        return () -> {
+            String traceId = Tracer.getTraceId();
+            List<OpenSpan> trace = getCurrentTrace();
+            OpenSpan span = trace.remove(trace.size() - 1);
+
+            assertThat(traceId).isEqualTo(outsideTraceId);
+            assertThat(trace).isEqualTo(outsideTrace);
+            assertThat(span.getOperation()).isEqualTo(operation);
+            assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(outsideTraceId);
+            return null;
+        };
+    }
+
+    private static Runnable traceExpectingRunnableWithSpan(String operation) {
+        final String outsideTraceId = Tracer.getTraceId();
+        final List<OpenSpan> outsideTrace = getCurrentTrace();
+
+        return () -> {
+            String traceId = Tracer.getTraceId();
+            List<OpenSpan> trace = getCurrentTrace();
+            OpenSpan span = trace.remove(trace.size() - 1);
+
+            assertThat(traceId).isEqualTo(outsideTraceId);
+            assertThat(trace).isEqualTo(outsideTrace);
+            assertThat(span.getOperation()).isEqualTo(operation);
+            assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(outsideTraceId);
+        };
+    }
+
+    private static List<OpenSpan> getCurrentTrace() {
         return Tracer.copyTrace().map(trace -> {
             List<OpenSpan> spans = Lists.newArrayList();
             while (!trace.isEmpty()) {
                 spans.add(trace.pop().get());
             }
-            return spans;
+            return Lists.reverse(spans);
         }).orElse(Collections.emptyList());
     }
 }


### PR DESCRIPTION
Fixes #63

~This PR preserves the existing executor wrapping methods and their behavior. So users must explicitly opt-in to the new span-creating behavior.~

This is no longer true. The existing executor methods will now create a new span for tasks they run.