### PR TITLE
[improvement] CloseableTracer supports all SpanTypes

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/CloseableTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/CloseableTracer.java
@@ -36,7 +36,15 @@ public final class CloseableTracer implements AutoCloseable {
      * Opens a new {@link SpanType#LOCAL LOCAL} span for this thread's call trace, labeled with the provided operation.
      */
     public static CloseableTracer startSpan(String operation) {
-        Tracer.startSpan(operation);
+        return startSpan(operation, SpanType.LOCAL);
+    }
+
+    /**
+     * Opens a new span for this thread's call trace with the provided {@link SpanType},
+     * labeled with the provided operation.
+     */
+    public static CloseableTracer startSpan(String operation, SpanType spanType) {
+        Tracer.startSpan(operation, spanType);
         return INSTANCE;
     }
 

--- a/tracing/src/test/java/com/palantir/tracing/CloseableTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/CloseableTracerTest.java
@@ -18,6 +18,8 @@ package com.palantir.tracing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.tracing.api.OpenSpan;
+import com.palantir.tracing.api.SpanType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +35,19 @@ public final class CloseableTracerTest {
     @Test
     public void startsAndClosesSpan() {
         try (CloseableTracer tracer = CloseableTracer.startSpan("foo")) {
-            assertThat(Tracer.copyTrace().get().top()).isNotEmpty();
+            OpenSpan openSpan = Tracer.copyTrace().get().top().get();
+            assertThat(openSpan.getOperation()).isEqualTo("foo");
+            assertThat(openSpan.type()).isEqualTo(SpanType.LOCAL);
+        }
+        assertThat(Tracer.getAndClearTrace().top()).isEmpty();
+    }
+
+    @Test
+    public void startsAndClosesSpanWithType() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("foo", SpanType.CLIENT_OUTGOING)) {
+            OpenSpan openSpan = Tracer.copyTrace().get().top().get();
+            assertThat(openSpan.getOperation()).isEqualTo("foo");
+            assertThat(openSpan.type()).isEqualTo(SpanType.CLIENT_OUTGOING);
         }
         assertThat(Tracer.getAndClearTrace().top()).isEmpty();
     }


### PR DESCRIPTION
## Before this PR
CloseableTracer only supported the LOCAL SpanType.

## After this PR
CloseableTracer only supports all SpanTypes.