### PR TITLE
[improvement] Add support for tracing-aware Guava FutureCallbacks.

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -214,50 +214,6 @@ public final class Tracers {
     }
 
     /**
-     * Like {@link #wrapWithNewTrace(Callable)}, but for Guava's FutureCallback.
-     */
-    public static <V> FutureCallback<V> wrapWithNewTrace(FutureCallback<V> delegate) {
-        return wrapWithNewTrace(ROOT_SPAN_OPERATION, delegate);
-    }
-
-    /**
-     * Like {@link #wrapWithNewTrace(String, Callable)}, but for Guava's FutureCallback.
-     */
-    public static <V> FutureCallback<V> wrapWithNewTrace(String operation, FutureCallback<V> delegate) {
-        return new FutureCallback<V>() {
-            @Override
-            public void onSuccess(@NullableDecl V result) {
-                // clear the existing trace and keep it around for restoration when we're done
-                Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
-
-                try {
-                    Tracer.initTrace(Optional.empty(), Tracers.randomId());
-                    Tracer.startSpan(operation);
-                    delegate.onSuccess(result);
-                } finally {
-                    Tracer.fastCompleteSpan();
-                    restoreTrace(originalTrace);
-                }
-            }
-
-            @Override
-            public void onFailure(Throwable throwable) {
-                // clear the existing trace and keep it around for restoration when we're done
-                Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
-
-                try {
-                    Tracer.initTrace(Optional.empty(), Tracers.randomId());
-                    Tracer.startSpan(operation);
-                    delegate.onFailure(throwable);
-                } finally {
-                    Tracer.fastCompleteSpan();
-                    restoreTrace(originalTrace);
-                }
-            }
-        };
-    }
-
-    /**
      * Like {@link #wrapWithAlternateTraceId(String, String, Runnable)}, but with a default initial span operation.
      */
     public static Runnable wrapWithAlternateTraceId(String traceId, Runnable delegate) {

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -135,9 +135,9 @@ public final class Tracers {
         return new TracingAwareRunnable(Optional.empty(), delegate);
     }
 
-    /** Like {@link #wrap(Callable)}, but for Guava's FutureCallback. */
-    public static <V> FutureCallback<V> wrap(FutureCallback<V> delegate) {
-        return new TracingAwareFutureCallback<>(delegate);
+    /** Like {@link #wrap(String, Callable)}, but for Guava's FutureCallback. */
+    public static <V> FutureCallback<V> wrap(String operation, FutureCallback<V> delegate) {
+        return new TracingAwareFutureCallback<>(operation, delegate);
     }
 
     /**
@@ -368,9 +368,9 @@ public final class Tracers {
         private final FutureCallback<V> delegate;
         private DeferredTracer deferredTracer;
 
-        TracingAwareFutureCallback(FutureCallback<V> delegate) {
+        TracingAwareFutureCallback(String operation, FutureCallback<V> delegate) {
             this.delegate = delegate;
-            this.deferredTracer = new DeferredTracer();
+            this.deferredTracer = new DeferredTracer(operation);
         }
 
         @Override

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -528,7 +528,7 @@ public final class TracersTest {
 
 
         Tracer.startSpan("outside");
-        FutureCallback<Void> successCallback = Tracers.wrap(futureCallback);
+        FutureCallback<Void> successCallback = Tracers.wrap("successCallback", futureCallback);
         Futures.addCallback(success, successCallback, Executors.newSingleThreadExecutor());
         success.get();
         assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("outside");
@@ -555,7 +555,7 @@ public final class TracersTest {
         });
 
         Tracer.startSpan("outside");
-        FutureCallback<Void> failureCallback = Tracers.wrap(futureCallback);
+        FutureCallback<Void> failureCallback = Tracers.wrap("failureCallback", futureCallback);
         Futures.addCallback(failure, failureCallback, Executors.newSingleThreadExecutor());
         assertThatThrownBy(failure::get).isInstanceOf(ExecutionException.class);
         assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("outside");
@@ -580,7 +580,7 @@ public final class TracersTest {
         ListenableFuture<Void> success = listeningExecutorService.submit(() -> null);
 
         Tracer.startSpan("before-construction");
-        FutureCallback<Void> successCallback = Tracers.wrap(futureCallback);
+        FutureCallback<Void> successCallback = Tracers.wrap("successCallback", futureCallback);
         Tracer.startSpan("after-construction");
         Futures.addCallback(success, successCallback, Executors.newSingleThreadExecutor());
         success.get();
@@ -607,7 +607,7 @@ public final class TracersTest {
         });
 
         Tracer.startSpan("before-construction");
-        FutureCallback<Void> failureCallback = Tracers.wrap(futureCallback);
+        FutureCallback<Void> failureCallback = Tracers.wrap("failureCallback", futureCallback);
         Tracer.startSpan("after-construction");
         Futures.addCallback(failure, failureCallback, Executors.newSingleThreadExecutor());
         assertThatThrownBy(failure::get).isInstanceOf(ExecutionException.class);


### PR DESCRIPTION
## Before this PR
Functionality defined as part of a Guava FutureCallback may not be correctly traced as the thread it runs on may not be the thread adding the callback.

## After this PR
FutureCallbacks can be wrapped such that their traces are parented to the thread adding the callback or wrapped in a new trace if desired.
