### PR TITLE
When Tracer.completeSpan() result is unused, prefer fastCompleteSpan

### DIFF
--- a/tracing-okhttp3/src/main/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptor.java
+++ b/tracing-okhttp3/src/main/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptor.java
@@ -56,7 +56,7 @@ public enum OkhttpTraceInterceptor implements Interceptor {
         try {
             response = chain.proceed(tracedRequest.build());
         } finally {
-            Tracer.completeSpan();
+            Tracer.fastCompleteSpan();
         }
 
         return response;

--- a/tracing-okhttp3/src/test/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptorTest.java
+++ b/tracing-okhttp3/src/test/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptorTest.java
@@ -89,7 +89,7 @@ public final class OkhttpTraceInterceptorTest {
         try {
             OkhttpTraceInterceptor.INSTANCE.intercept(chain);
         } finally {
-            Tracer.completeSpan();
+            Tracer.fastCompleteSpan();
         }
 
         verify(chain).request();

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -21,6 +21,7 @@ import static com.palantir.logsafe.Preconditions.checkNotNull;
 import static com.palantir.logsafe.Preconditions.checkState;
 
 import com.google.common.base.Strings;
+import com.google.errorprone.annotations.CheckReturnValue;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.tracing.api.OpenSpan;
@@ -167,14 +168,18 @@ public final class Tracer {
     /**
      * Completes and returns the current span (if it exists) and notifies all {@link #observers subscribers} about the
      * completed span.
+     * If the return value is not used, prefer {@link Tracer#fastCompleteSpan()}.
      */
+    @CheckReturnValue
     public static Optional<Span> completeSpan() {
         return completeSpan(Collections.emptyMap());
     }
 
     /**
      * Like {@link #completeSpan()}, but adds {@code metadata} to the current span being completed.
+     * If the return value is not used, prefer {@link Tracer#fastCompleteSpan(Map)}.
      */
+    @CheckReturnValue
     public static Optional<Span> completeSpan(Map<String, String> metadata) {
         Trace trace = currentTrace.get();
         if (trace == null) {

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -122,7 +122,7 @@ public final class TracerTest {
     public void testDoesNotNotifyObserversWhenCompletingNonexistingSpan() throws Exception {
         Tracer.subscribe("1", observer1);
         Tracer.subscribe("2", observer2);
-        Tracer.completeSpan(); // no active span.
+        Tracer.fastCompleteSpan(); // no active span.
         verifyNoMoreInteractions(observer1, observer2);
     }
 
@@ -308,7 +308,7 @@ public final class TracerTest {
         try {
             assertThat(Tracer.hasTraceId()).isEqualTo(true);
         } finally {
-            Tracer.completeSpan();
+            Tracer.fastCompleteSpan();
         }
         assertThat(Tracer.hasTraceId()).isEqualTo(false);
     }

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -71,9 +71,9 @@ public final class TracersTest {
         Tracer.startSpan("baz");
         wrappedService.submit(traceExpectingCallableWithSpan("executor")).get();
         wrappedService.submit(traceExpectingRunnableWithSpan("executor")).get();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
+        Tracer.fastCompleteSpan();
+        Tracer.fastCompleteSpan();
+        Tracer.fastCompleteSpan();
     }
 
     @Test
@@ -91,9 +91,9 @@ public final class TracersTest {
         Tracer.startSpan("baz");
         wrappedService.submit(traceExpectingCallableWithSpan("operation")).get();
         wrappedService.submit(traceExpectingRunnableWithSpan("operation")).get();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
+        Tracer.fastCompleteSpan();
+        Tracer.fastCompleteSpan();
+        Tracer.fastCompleteSpan();
     }
 
     @Test
@@ -111,9 +111,9 @@ public final class TracersTest {
         Tracer.startSpan("baz");
         wrappedService.schedule(traceExpectingCallableWithSpan("executor"), 0, TimeUnit.SECONDS).get();
         wrappedService.schedule(traceExpectingRunnableWithSpan("executor"), 0, TimeUnit.SECONDS).get();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
+        Tracer.fastCompleteSpan();
+        Tracer.fastCompleteSpan();
+        Tracer.fastCompleteSpan();
     }
 
     @Test
@@ -131,9 +131,9 @@ public final class TracersTest {
         Tracer.startSpan("baz");
         wrappedService.schedule(traceExpectingCallableWithSpan("operation"), 0, TimeUnit.SECONDS).get();
         wrappedService.schedule(traceExpectingRunnableWithSpan("operation"), 0, TimeUnit.SECONDS).get();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
+        Tracer.fastCompleteSpan();
+        Tracer.fastCompleteSpan();
+        Tracer.fastCompleteSpan();
     }
 
     @Test
@@ -157,9 +157,9 @@ public final class TracersTest {
         Tracer.startSpan("baz");
         wrappedService.submit(callable).get();
         wrappedService.submit(runnable).get();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
+        Tracer.fastCompleteSpan();
+        Tracer.fastCompleteSpan();
+        Tracer.fastCompleteSpan();
     }
 
     @Test
@@ -183,9 +183,9 @@ public final class TracersTest {
         Tracer.startSpan("baz");
         wrappedService.schedule(callable, 0, TimeUnit.SECONDS).get();
         wrappedService.schedule(runnable, 0, TimeUnit.SECONDS).get();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
-        Tracer.completeSpan();
+        Tracer.fastCompleteSpan();
+        Tracer.fastCompleteSpan();
+        Tracer.fastCompleteSpan();
     }
 
     @Test


### PR DESCRIPTION
The latter avoids work when operations are not sampled, which is
significantly more common than sampling.

Added error-prone annotations to validate correct usage.