### PR TITLE
[improvement] Revert adding spans to all wrapped executor tasks

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -27,7 +27,6 @@ public final class Tracers {
     /** The key under which trace ids are inserted into SLF4J {@link org.slf4j.MDC MDCs}. */
     public static final String TRACE_ID_KEY = "traceId";
     private static final String DEFAULT_ROOT_SPAN_OPERATION = "root";
-    private static final String DEFAULT_EXECUTOR_SPAN_OPERATION = "executor";
     private static final char[] HEX_DIGITS =
             {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
@@ -69,7 +68,12 @@ public final class Tracers {
      * #wrap wrapped} in order to be trace-aware.
      */
     public static ExecutorService wrap(ExecutorService executorService) {
-        return wrap(DEFAULT_EXECUTOR_SPAN_OPERATION, executorService);
+        return new WrappingExecutorService(executorService) {
+            @Override
+            protected <T> Callable<T> wrapTask(Callable<T> callable) {
+                return wrap(callable);
+            }
+        };
     }
 
     /**
@@ -92,7 +96,12 @@ public final class Tracers {
      * trace will be generated for each execution, effectively bypassing the intent of this method.
      */
     public static ScheduledExecutorService wrap(ScheduledExecutorService executorService) {
-        return wrap(DEFAULT_EXECUTOR_SPAN_OPERATION, executorService);
+        return new WrappingScheduledExecutorService(executorService) {
+            @Override
+            protected <T> Callable<T> wrapTask(Callable<T> callable) {
+                return wrap(callable);
+            }
+        };
     }
 
     /**

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -62,15 +62,15 @@ public final class TracersTest {
                 Tracers.wrap(Executors.newSingleThreadExecutor());
 
         // Empty trace
-        wrappedService.submit(traceExpectingCallableWithSpan("executor")).get();
-        wrappedService.submit(traceExpectingRunnableWithSpan("executor")).get();
+        wrappedService.submit(traceExpectingCallable()).get();
+        wrappedService.submit(traceExpectingCallable()).get();
 
         // Non-empty trace
         Tracer.startSpan("foo");
         Tracer.startSpan("bar");
         Tracer.startSpan("baz");
-        wrappedService.submit(traceExpectingCallableWithSpan("executor")).get();
-        wrappedService.submit(traceExpectingRunnableWithSpan("executor")).get();
+        wrappedService.submit(traceExpectingCallable()).get();
+        wrappedService.submit(traceExpectingCallable()).get();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
@@ -102,15 +102,15 @@ public final class TracersTest {
                 Tracers.wrap(Executors.newSingleThreadScheduledExecutor());
 
         // Empty trace
-        wrappedService.schedule(traceExpectingCallableWithSpan("executor"), 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(traceExpectingRunnableWithSpan("executor"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingCallable(), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingCallable(), 0, TimeUnit.SECONDS).get();
 
         // Non-empty trace
         Tracer.startSpan("foo");
         Tracer.startSpan("bar");
         Tracer.startSpan("baz");
-        wrappedService.schedule(traceExpectingCallableWithSpan("executor"), 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(traceExpectingRunnableWithSpan("executor"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingCallable(), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingCallable(), 0, TimeUnit.SECONDS).get();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();


### PR DESCRIPTION
## Before this PR
In https://github.com/palantir/tracing-java/pull/71, all wrapped executor tasks had spans added by default. This was pretty noisy for tasks that were already doing their own wrapping.

## After this PR
If wrapping is not explicitly requested, it is not done