### PR TITLE
[improvement] wrapWithAlternateTraceId accepts observable state

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -270,7 +270,7 @@ public final class Tracers {
     /**
      * Deprecated.
      *
-     * @deprecated Use {@link #wrapWithAlternateTraceId(String, String, Runnable)}
+     * @deprecated Use {@link #wrapWithAlternateTraceId(String, Optional, String, Runnable)}
      */
     @Deprecated
     public static Runnable wrapWithAlternateTraceId(String traceId, Runnable delegate) {
@@ -278,20 +278,33 @@ public final class Tracers {
     }
 
     /**
-     * Wraps the given {@link Runnable} such that it creates a fresh {@link Trace tracing state with the given traceId}
-     * for its execution. That is, the trace during its {@link Runnable#run() execution} will use the traceId provided
-     * instead of any trace already set on the thread used to execute the runnable. Each execution of the runnable
-     * will use a new {@link Trace tracing state} with the same given traceId.  The given {@link String operation} is
-     * used to create the initial span.
+     * Deprecated.
+     *
+     * @deprecated Use {@link #wrapWithAlternateTraceId(String, Optional, String, Runnable)}
      */
-    public static Runnable wrapWithAlternateTraceId(String traceId, String operation, Runnable
-            delegate) {
+    @Deprecated
+    public static Runnable wrapWithAlternateTraceId(String traceId, String operation, Runnable delegate) {
+        return wrapWithAlternateTraceId(traceId, Optional.empty(), operation, delegate);
+    }
+
+    /**
+     * Wraps the given {@link Runnable} such that it creates a fresh {@link Trace tracing state with the give traceId
+     * and observability} for its execution. That is, the trace during its {@link Runnable#run() execution} will use
+     * the traceId provided instead of any trace already set on the thread used to execute the runnable. Each
+     * execution of the runnable will use a new {@link Trace tracing state} with the same given traceId.  The given
+     * {@link String operation} is used to create the initial span.
+     */
+    public static Runnable wrapWithAlternateTraceId(
+            String traceId,
+            Optional<Boolean> isObservable,
+            String operation,
+            Runnable delegate) {
         return () -> {
             // clear the existing trace and keep it around for restoration when we're done
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
-                Tracer.initTrace(Optional.empty(), traceId);
+                Tracer.initTrace(isObservable, traceId);
                 Tracer.startSpan(operation);
                 delegate.run();
             } finally {

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -19,6 +19,7 @@ package com.palantir.tracing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.palantir.tracing.api.OpenSpan;
 import java.util.Collections;
@@ -499,6 +500,18 @@ public final class TracersTest {
             // no-op
         }).run();
         assertThat(Tracer.hasTraceId()).isFalse();
+    }
+
+    @Test
+    public void testWrapRunnableWithAlternateTraceId_traceStateInsideRunnableHasGivenObservableState() {
+        for (Boolean isObservable : ImmutableList.of(true, false)) {
+            Tracers.wrapWithAlternateTraceId(
+                    "someTraceId",
+                    Optional.of(isObservable),
+                    "operation",
+                    () -> assertThat(Tracer.isTraceObservable()).isEqualTo(isObservable)
+            ).run();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
wrapWithAlternateTraceId did not accept the observable state to use. That means that a trace that was originally observable would not be fully observed when being propagated through this method.
An example of when this would be an issue if when propagating a trace from a Spark driver to a Spark executor, for instance by implementing a `ForeachPartitionFunction`.

## After this PR
The observable state can be properly propagated via wrapWithAlternateTraceId