### PR TITLE
make `DeferredTracer` serializable

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
@@ -48,8 +48,9 @@ public final class DeferredTracer implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static final String UNKNOWN_OPERATION = "deferred";
+    private static final String DEFAULT_OPERATION = "deferred";
 
+    @Nullable
     private final String traceId;
     private final boolean isObservable;
     @Nullable
@@ -76,7 +77,7 @@ public final class DeferredTracer implements Serializable {
             this.traceId = trace.getTraceId();
             this.isObservable = trace.isObservable();
             this.parentSpanId = trace.top().map(OpenSpan::getSpanId).orElse(null);
-            this.operation = operation.orElse(trace.top().map(OpenSpan::getOperation).orElse(UNKNOWN_OPERATION));
+            this.operation = operation.orElse(trace.top().map(OpenSpan::getOperation).orElse(DEFAULT_OPERATION));
         } else {
             this.traceId = null;
             this.isObservable = false;

--- a/tracing/src/test/java/com/palantir/tracing/DeferredTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/DeferredTracerTest.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tracing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Optional;
+import org.junit.Test;
+
+public class DeferredTracerTest {
+
+    @Test
+    public void testIsSerializable() throws IOException, ClassNotFoundException {
+        Tracer.initTrace(Optional.empty(), "defaultTraceId");
+
+        DeferredTracer deferredTracer = new DeferredTracer();
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(baos)) {
+            objectOutputStream.writeObject(deferredTracer);
+        }
+
+        Tracer.initTrace(Optional.empty(), "someOtherTraceId");
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(bais)) {
+            DeferredTracer deserialized = (DeferredTracer) objectInputStream.readObject();
+
+            String trace = deserialized.withTrace(() -> Tracer.getTraceId());
+            assertThat(trace).isEqualTo("defaultTraceId");
+        }
+    }
+}

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -545,38 +545,6 @@ public final class TracersTest {
         };
     }
 
-    private static Callable<Void> traceExpectingCallable() {
-        final String outsideTraceId = Tracer.getTraceId();
-        final List<OpenSpan> outsideTrace = getCurrentTrace();
-
-        return () -> {
-            String traceId = Tracer.getTraceId();
-            List<OpenSpan> trace = getCurrentTrace();
-
-            assertThat(traceId).isEqualTo(outsideTraceId);
-            assertThat(trace).isEqualTo(outsideTrace);
-            assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(outsideTraceId);
-            return null;
-        };
-    }
-
-    private static Callable<Void> traceExpectingCallableWithSpan(String operation) {
-        final String outsideTraceId = Tracer.getTraceId();
-        final List<OpenSpan> outsideTrace = getCurrentTrace();
-
-        return () -> {
-            String traceId = Tracer.getTraceId();
-            List<OpenSpan> trace = getCurrentTrace();
-            OpenSpan span = trace.remove(trace.size() - 1);
-
-            assertThat(traceId).isEqualTo(outsideTraceId);
-            assertThat(trace).isEqualTo(outsideTrace);
-            assertThat(span.getOperation()).isEqualTo(operation);
-            assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(outsideTraceId);
-            return null;
-        };
-    }
-
     private static Callable<Void> traceExpectingCallableWithSingleSpan(String operation) {
         final String outsideTraceId = Tracer.getTraceId();
 
@@ -590,22 +558,6 @@ public final class TracersTest {
             assertThat(span.getOperation()).isEqualTo(operation);
             assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(outsideTraceId);
             return null;
-        };
-    }
-
-    private static Runnable traceExpectingRunnableWithSpan(String operation) {
-        final String outsideTraceId = Tracer.getTraceId();
-        final List<OpenSpan> outsideTrace = getCurrentTrace();
-
-        return () -> {
-            String traceId = Tracer.getTraceId();
-            List<OpenSpan> trace = getCurrentTrace();
-            OpenSpan span = trace.remove(trace.size() - 1);
-
-            assertThat(traceId).isEqualTo(outsideTraceId);
-            assertThat(trace).isEqualTo(outsideTrace);
-            assertThat(span.getOperation()).isEqualTo(operation);
-            assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(outsideTraceId);
         };
     }
 

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -62,15 +62,15 @@ public final class TracersTest {
                 Tracers.wrap(Executors.newSingleThreadExecutor());
 
         // Empty trace
-        wrappedService.submit(traceExpectingCallable()).get();
-        wrappedService.submit(traceExpectingCallable()).get();
+        wrappedService.submit(traceExpectingCallableWithSingleSpan("deferred")).get();
+        wrappedService.submit(traceExpectingCallableWithSingleSpan("deferred")).get();
 
         // Non-empty trace
         Tracer.startSpan("foo");
         Tracer.startSpan("bar");
         Tracer.startSpan("baz");
-        wrappedService.submit(traceExpectingCallable()).get();
-        wrappedService.submit(traceExpectingCallable()).get();
+        wrappedService.submit(traceExpectingCallableWithSingleSpan("baz")).get();
+        wrappedService.submit(traceExpectingCallableWithSingleSpan("baz")).get();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
@@ -82,15 +82,15 @@ public final class TracersTest {
                 Tracers.wrap("operation", Executors.newSingleThreadExecutor());
 
         // Empty trace
-        wrappedService.submit(traceExpectingCallableWithSpan("operation")).get();
-        wrappedService.submit(traceExpectingRunnableWithSpan("operation")).get();
+        wrappedService.submit(traceExpectingCallableWithSingleSpan("operation")).get();
+        wrappedService.submit(traceExpectingRunnableWithSingleSpan("operation")).get();
 
         // Non-empty trace
         Tracer.startSpan("foo");
         Tracer.startSpan("bar");
         Tracer.startSpan("baz");
-        wrappedService.submit(traceExpectingCallableWithSpan("operation")).get();
-        wrappedService.submit(traceExpectingRunnableWithSpan("operation")).get();
+        wrappedService.submit(traceExpectingCallableWithSingleSpan("operation")).get();
+        wrappedService.submit(traceExpectingRunnableWithSingleSpan("operation")).get();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
@@ -102,15 +102,15 @@ public final class TracersTest {
                 Tracers.wrap(Executors.newSingleThreadScheduledExecutor());
 
         // Empty trace
-        wrappedService.schedule(traceExpectingCallable(), 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(traceExpectingCallable(), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingCallableWithSingleSpan("deferred"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingRunnableWithSingleSpan("deferred"), 0, TimeUnit.SECONDS).get();
 
         // Non-empty trace
         Tracer.startSpan("foo");
         Tracer.startSpan("bar");
         Tracer.startSpan("baz");
-        wrappedService.schedule(traceExpectingCallable(), 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(traceExpectingCallable(), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingCallableWithSingleSpan("baz"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingRunnableWithSingleSpan("baz"), 0, TimeUnit.SECONDS).get();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
@@ -122,15 +122,15 @@ public final class TracersTest {
                 Tracers.wrap("operation", Executors.newSingleThreadScheduledExecutor());
 
         // Empty trace
-        wrappedService.schedule(traceExpectingCallableWithSpan("operation"), 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(traceExpectingRunnableWithSpan("operation"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingCallableWithSingleSpan("operation"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingRunnableWithSingleSpan("operation"), 0, TimeUnit.SECONDS).get();
 
         // Non-empty trace
         Tracer.startSpan("foo");
         Tracer.startSpan("bar");
         Tracer.startSpan("baz");
-        wrappedService.schedule(traceExpectingCallableWithSpan("operation"), 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(traceExpectingRunnableWithSpan("operation"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingCallableWithSingleSpan("operation"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingRunnableWithSingleSpan("operation"), 0, TimeUnit.SECONDS).get();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
@@ -577,6 +577,22 @@ public final class TracersTest {
         };
     }
 
+    private static Callable<Void> traceExpectingCallableWithSingleSpan(String operation) {
+        final String outsideTraceId = Tracer.getTraceId();
+
+        return () -> {
+            String traceId = Tracer.getTraceId();
+            List<OpenSpan> trace = getCurrentTrace();
+            OpenSpan span = trace.remove(trace.size() - 1);
+            assertThat(trace.size()).isEqualTo(0);
+
+            assertThat(traceId).isEqualTo(outsideTraceId);
+            assertThat(span.getOperation()).isEqualTo(operation);
+            assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(outsideTraceId);
+            return null;
+        };
+    }
+
     private static Runnable traceExpectingRunnableWithSpan(String operation) {
         final String outsideTraceId = Tracer.getTraceId();
         final List<OpenSpan> outsideTrace = getCurrentTrace();
@@ -588,6 +604,21 @@ public final class TracersTest {
 
             assertThat(traceId).isEqualTo(outsideTraceId);
             assertThat(trace).isEqualTo(outsideTrace);
+            assertThat(span.getOperation()).isEqualTo(operation);
+            assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(outsideTraceId);
+        };
+    }
+
+    private static Runnable traceExpectingRunnableWithSingleSpan(String operation) {
+        final String outsideTraceId = Tracer.getTraceId();
+
+        return () -> {
+            String traceId = Tracer.getTraceId();
+            List<OpenSpan> trace = getCurrentTrace();
+            OpenSpan span = trace.remove(trace.size() - 1);
+            assertThat(trace.size()).isEqualTo(0);
+
+            assertThat(traceId).isEqualTo(outsideTraceId);
             assertThat(span.getOperation()).isEqualTo(operation);
             assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(outsideTraceId);
         };


### PR DESCRIPTION
alternate approach to #95 

## Before this PR
I want to have traces span work done on worker nodes running in separate jvms (e.g. spark executors). I could previously have captured the traceid and then used Tracers.wrapWithAlternateTraceId(...) but this loses parent span info/isObservable.

## After this PR
I can create a `DeferredTracer` on the master node and have that be serialized out to the worker nodes.
