### PR TITLE
Adds key traceSampled to MDC when set trace is observable

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -331,8 +331,18 @@ public final class Tracer {
     static void setTrace(Trace trace) {
         currentTrace.set(trace);
 
-        // Give SLF4J appenders access to the trace id
+        // Give SLF4J appenders access to the trace id and if trace is being sampled
         MDC.put(Tracers.TRACE_ID_KEY, trace.getTraceId());
+        setTraceSampledMdcIfObservable(trace.isObservable());
+    }
+
+    private static void setTraceSampledMdcIfObservable(boolean isObservable) {
+        if (isObservable) {
+            MDC.put(Tracers.TRACE_SAMPLED_KEY, "1");
+        } else {
+            // To ensure MDC state is cleared when trace is not observable
+            MDC.remove(Tracers.TRACE_SAMPLED_KEY);
+        }
     }
 
     private static Trace getOrCreateCurrentTrace() {
@@ -347,5 +357,6 @@ public final class Tracer {
     private static void clearCurrentTrace() {
         currentTrace.remove();
         MDC.remove(Tracers.TRACE_ID_KEY);
+        MDC.remove(Tracers.TRACE_SAMPLED_KEY);
     }
 }

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -331,13 +331,14 @@ public final class Tracer {
     static void setTrace(Trace trace) {
         currentTrace.set(trace);
 
-        // Give SLF4J appenders access to the trace id and if trace is being sampled
+        // Give log appenders access to the trace id and whether the trace is being sampled
         MDC.put(Tracers.TRACE_ID_KEY, trace.getTraceId());
         setTraceSampledMdcIfObservable(trace.isObservable());
     }
 
-    private static void setTraceSampledMdcIfObservable(boolean isObservable) {
-        if (isObservable) {
+    private static void setTraceSampledMdcIfObservable(boolean observable) {
+        if (observable) {
+            // Set to 1 to be consistent with values associated with http header key TraceHttpHeaders.IS_SAMPLED
             MDC.put(Tracers.TRACE_SAMPLED_KEY, "1");
         } else {
             // To ensure MDC state is cleared when trace is not observable

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ThreadLocalRandom;
 public final class Tracers {
     /** The key under which trace ids are inserted into SLF4J {@link org.slf4j.MDC MDCs}. */
     public static final String TRACE_ID_KEY = "traceId";
+    public static final String TRACE_SAMPLED_KEY = "traceSampled";
     private static final String DEFAULT_ROOT_SPAN_OPERATION = "root";
     private static final char[] HEX_DIGITS =
             {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -191,6 +191,22 @@ public final class TracerTest {
     }
 
     @Test
+    public void testSetTraceSetsMdcTraceSampledKeyWhenObserved() {
+        Tracer.setTrace(new Trace(true, "observedTraceId"));
+        assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isEqualTo("1");
+        assertThat(Tracer.completeSpan()).isEmpty();
+        assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isNull();
+    }
+
+    @Test
+    public void testSetTraceMissingMdcTraceSampledKeyWhenNotObserved() {
+        Tracer.setTrace(new Trace(false, "notObservedTraceId"));
+        assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isNull();
+        assertThat(Tracer.completeSpan()).isEmpty();
+        assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isNull();
+    }
+
+    @Test
     public void testCompletedSpanHasCorrectSpanType() throws Exception {
         for (SpanType type : SpanType.values()) {
             Tracer.startSpan("1", type);


### PR DESCRIPTION
## Before this PR
Log consumers were unable to tell which traces were sampled (observable: true) vs which traces were not sampled (observable: false). 

## After this PR
An MDC key traceSampled will now appear with the value "1" when the set trace has been sampled (observable: true). If the set trace is not sampled (observable: false), the key will not appear in the MDC.
