### PR TITLE
[fix] Don't use parent span operation in deferred traces

### DIFF
--- a/tracing-jaxrs/src/main/java/com/palantir/tracing/jaxrs/JaxRsTracers.java
+++ b/tracing-jaxrs/src/main/java/com/palantir/tracing/jaxrs/JaxRsTracers.java
@@ -40,7 +40,7 @@ public final class JaxRsTracers {
 
         TracingAwareStreamingOutput(StreamingOutput delegate) {
             this.delegate = delegate;
-            this.deferredTracer = new DeferredTracer();
+            this.deferredTracer = new DeferredTracer("streaming-output");
         }
 
         @Override

--- a/tracing-jaxrs/src/test/java/com/palantir/tracing/jaxrs/JaxRsTracersTest.java
+++ b/tracing-jaxrs/src/test/java/com/palantir/tracing/jaxrs/JaxRsTracersTest.java
@@ -39,7 +39,7 @@ public final class JaxRsTracersTest {
     public void testWrappingStreamingOutput_traceStateIsCapturedAtConstructionTime() throws Exception {
         Tracer.startSpan("before-construction");
         StreamingOutput streamingOutput = JaxRsTracers.wrap(os -> {
-            assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("before-construction");
+            assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("streaming-output");
         });
         Tracer.startSpan("after-construction");
         streamingOutput.write(new ByteArrayOutputStream());

--- a/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
@@ -53,31 +53,38 @@ public final class DeferredTracer implements Serializable {
     @Nullable
     private final String traceId;
     private final boolean isObservable;
-    @Nullable
     private final String operation;
     @Nullable
     private final String parentSpanId;
 
+    /**
+     * Deprecated.
+     *
+     * @deprecated Use {@link #DeferredTracer(String)}
+     */
+    @Deprecated
     public DeferredTracer() {
         this(Optional.empty());
     }
 
-    public DeferredTracer(String operation) {
-        this(Optional.of(operation));
+    /**
+     * Deprecated.
+     *
+     * @deprecated Use {@link #DeferredTracer(String)}
+     */
+    @Deprecated
+    public DeferredTracer(Optional<String> operation) {
+        this(operation.orElse(DEFAULT_OPERATION));
     }
 
-    /**
-     * Create a new deferred tracer, optionally specifying an operation.
-     * If no operation is specified, will attempt to use the parent span's operation name.
-     */
-    public DeferredTracer(Optional<String> operation) {
+    public DeferredTracer(String operation) {
         Optional<Trace> maybeTrace = Tracer.copyTrace();
         if (maybeTrace.isPresent()) {
             Trace trace = maybeTrace.get();
             this.traceId = trace.getTraceId();
             this.isObservable = trace.isObservable();
             this.parentSpanId = trace.top().map(OpenSpan::getSpanId).orElse(null);
-            this.operation = operation.orElse(trace.top().map(OpenSpan::getOperation).orElse(DEFAULT_OPERATION));
+            this.operation = operation;
         } else {
             this.traceId = null;
             this.isObservable = false;

--- a/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
@@ -48,7 +48,7 @@ public final class DeferredTracer implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static final String DEFAULT_OPERATION = "deferred";
+    private static final String DEFAULT_OPERATION = "DeferredTracer(unnamed operation)";
 
     @Nullable
     private final String traceId;

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -328,6 +328,7 @@ public final class Tracers {
      * intuitively expected) tracing state, we remember the original state and set it for the duration of the
      * {@link #call() execution}.
      */
+    @SuppressWarnings("deprecation")
     private static class TracingAwareCallable<V> implements Callable<V> {
         private final Callable<V> delegate;
         private final DeferredTracer deferredTracer;
@@ -347,6 +348,7 @@ public final class Tracers {
      * Wraps a given runnable such that its execution operates with the {@link Trace thread-local Trace} of the thread
      * that constructs the {@link TracingAwareRunnable} instance rather than the thread that executes the runnable.
      */
+    @SuppressWarnings("deprecation")
     private static class TracingAwareRunnable implements Runnable {
         private final Runnable delegate;
         private DeferredTracer deferredTracer;

--- a/tracing/src/test/java/com/palantir/tracing/DeferredTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/DeferredTracerTest.java
@@ -32,7 +32,7 @@ public class DeferredTracerTest {
     public void testIsSerializable() throws IOException, ClassNotFoundException {
         Tracer.initTrace(Optional.empty(), "defaultTraceId");
 
-        DeferredTracer deferredTracer = new DeferredTracer();
+        DeferredTracer deferredTracer = new DeferredTracer("operation");
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(baos)) {

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -62,15 +62,15 @@ public final class TracersTest {
                 Tracers.wrap(Executors.newSingleThreadExecutor());
 
         // Empty trace
-        wrappedService.submit(traceExpectingCallableWithSingleSpan("deferred")).get();
-        wrappedService.submit(traceExpectingCallableWithSingleSpan("deferred")).get();
+        wrappedService.submit(traceExpectingCallableWithSingleSpan("DeferredTracer(unnamed operation)")).get();
+        wrappedService.submit(traceExpectingCallableWithSingleSpan("DeferredTracer(unnamed operation)")).get();
 
         // Non-empty trace
         Tracer.startSpan("foo");
         Tracer.startSpan("bar");
         Tracer.startSpan("baz");
-        wrappedService.submit(traceExpectingCallableWithSingleSpan("deferred")).get();
-        wrappedService.submit(traceExpectingCallableWithSingleSpan("deferred")).get();
+        wrappedService.submit(traceExpectingCallableWithSingleSpan("DeferredTracer(unnamed operation)")).get();
+        wrappedService.submit(traceExpectingCallableWithSingleSpan("DeferredTracer(unnamed operation)")).get();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
@@ -102,15 +102,19 @@ public final class TracersTest {
                 Tracers.wrap(Executors.newSingleThreadScheduledExecutor());
 
         // Empty trace
-        wrappedService.schedule(traceExpectingCallableWithSingleSpan("deferred"), 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(traceExpectingRunnableWithSingleSpan("deferred"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(
+                traceExpectingCallableWithSingleSpan("DeferredTracer(unnamed operation)"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(
+                traceExpectingRunnableWithSingleSpan("DeferredTracer(unnamed operation)"), 0, TimeUnit.SECONDS).get();
 
         // Non-empty trace
         Tracer.startSpan("foo");
         Tracer.startSpan("bar");
         Tracer.startSpan("baz");
-        wrappedService.schedule(traceExpectingCallableWithSingleSpan("deferred"), 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(traceExpectingRunnableWithSingleSpan("deferred"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(
+                traceExpectingCallableWithSingleSpan("DeferredTracer(unnamed operation)"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(
+                traceExpectingRunnableWithSingleSpan("DeferredTracer(unnamed operation)"), 0, TimeUnit.SECONDS).get();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
@@ -203,7 +207,7 @@ public final class TracersTest {
     public void testWrapCallable_traceStateIsCapturedAtConstructionTime() throws Exception {
         Tracer.startSpan("before-construction");
         Callable<Void> callable = Tracers.wrap(() -> {
-            assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("deferred");
+            assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("DeferredTracer(unnamed operation)");
             return null;
         });
         Tracer.startSpan("after-construction");
@@ -234,7 +238,7 @@ public final class TracersTest {
     public void testWrapRunnable_traceStateIsCapturedAtConstructionTime() throws Exception {
         Tracer.startSpan("before-construction");
         Runnable runnable = Tracers.wrap(() -> {
-            assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("deferred");
+            assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("DeferredTracer(unnamed operation)");
         });
         Tracer.startSpan("after-construction");
         runnable.run();

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -69,8 +69,8 @@ public final class TracersTest {
         Tracer.startSpan("foo");
         Tracer.startSpan("bar");
         Tracer.startSpan("baz");
-        wrappedService.submit(traceExpectingCallableWithSingleSpan("baz")).get();
-        wrappedService.submit(traceExpectingCallableWithSingleSpan("baz")).get();
+        wrappedService.submit(traceExpectingCallableWithSingleSpan("deferred")).get();
+        wrappedService.submit(traceExpectingCallableWithSingleSpan("deferred")).get();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
@@ -109,8 +109,8 @@ public final class TracersTest {
         Tracer.startSpan("foo");
         Tracer.startSpan("bar");
         Tracer.startSpan("baz");
-        wrappedService.schedule(traceExpectingCallableWithSingleSpan("baz"), 0, TimeUnit.SECONDS).get();
-        wrappedService.schedule(traceExpectingRunnableWithSingleSpan("baz"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingCallableWithSingleSpan("deferred"), 0, TimeUnit.SECONDS).get();
+        wrappedService.schedule(traceExpectingRunnableWithSingleSpan("deferred"), 0, TimeUnit.SECONDS).get();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
@@ -203,7 +203,7 @@ public final class TracersTest {
     public void testWrapCallable_traceStateIsCapturedAtConstructionTime() throws Exception {
         Tracer.startSpan("before-construction");
         Callable<Void> callable = Tracers.wrap(() -> {
-            assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("before-construction");
+            assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("deferred");
             return null;
         });
         Tracer.startSpan("after-construction");
@@ -234,7 +234,7 @@ public final class TracersTest {
     public void testWrapRunnable_traceStateIsCapturedAtConstructionTime() throws Exception {
         Tracer.startSpan("before-construction");
         Runnable runnable = Tracers.wrap(() -> {
-            assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("before-construction");
+            assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("deferred");
         });
         Tracer.startSpan("after-construction");
         runnable.run();


### PR DESCRIPTION
## Before this PR
When creating a deferred trace without specifying an operation, the parent span operation is used. This is confusing because:
1. It creates duplicate spans with the same operation name
2. The parent span operation name is likely not a good description of what the deferred trace task is doing.

## After this PR
When creating a deferred trace without specifying an operation, the default deferred span operation is used. The constructors that allow callers to not specify an operation have been deprecated a signal to clients that they should provide an operation for better trace logs.
