### PR TITLE
[experiment] Try building against java 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ jobs:
       - store_test_results: { path: ~/junit }
       - store_artifacts: { path: ~/artifacts }
 
-  build-11:
-    docker: [{ image: 'circleci/openjdk:11-node' }]
+  build-12:
+    docker: [{ image: 'circleci/openjdk:12-node' }]
     resource_class: xlarge
     environment:
       GRADLE_OPTS: -Dorg.gradle.console=plain -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false
@@ -77,7 +77,7 @@ workflows:
       - build:
           # CircleCI2 will ignore tags without this. https://circleci.com/docs/2.0/workflows/#git-tag-job-execution
           filters: { tags: { only: /.*/ } }
-      - build-11:
+      - build-12:
           # CircleCI2 will ignore tags without this. https://circleci.com/docs/2.0/workflows/#git-tag-job-execution
           filters: { tags: { only: /.*/ } }
       - markdown:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   build-12:
-    docker: [{ image: 'circleci/openjdk:12-node' }]
+    docker: [{ image: 'circleci/openjdk:12' }]
     resource_class: xlarge
     environment:
       GRADLE_OPTS: -Dorg.gradle.console=plain -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,12 +40,12 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   build-12:
-    docker: [{ image: 'circleci/openjdk:12' }]
+    docker: [{ image: 'openjdk:12' }]
     resource_class: xlarge
     environment:
       GRADLE_OPTS: -Dorg.gradle.console=plain -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false
-      CIRCLE_TEST_REPORTS: /home/circleci/junit
-      CIRCLE_ARTIFACTS: /home/circleci/artifacts
+      CIRCLE_TEST_REPORTS: /root/junit
+      CIRCLE_ARTIFACTS: /root/artifacts
       _JAVA_OPTIONS: '-XX:ActiveProcessorCount=8 -Xmx2048m'
     steps:
       - checkout

--- a/build.gradle
+++ b/build.gradle
@@ -32,25 +32,9 @@ buildscript {
     }
 }
 
-apply plugin: 'com.palantir.git-version'
-
+apply plugin: 'com.palantir.baseline'
 apply plugin: 'com.palantir.consistent-versions'
-
-// expanded version of 'com.palantir.baseline' because errorprone doesn't work on Java12 yet
-apply plugin: 'com.palantir.baseline-config'
-apply plugin: 'com.palantir.baseline-circleci'
-allprojects {
-    apply plugin: 'com.palantir.baseline-checkstyle'
-    apply plugin: 'com.palantir.baseline-scalastyle'
-    apply plugin: 'com.palantir.baseline-eclipse'
-    apply plugin: 'com.palantir.baseline-idea'
-    // apply plugin: 'com.palantir.baseline-error-prone'
-    // apply plugin: 'com.palantir.baseline-versions'
-    apply plugin: 'com.palantir.baseline-format'
-    apply plugin: 'com.palantir.baseline-reproducibility'
-    apply plugin: 'com.palantir.baseline-exact-dependencies'
-    apply plugin: 'com.palantir.baseline-release-compatibility'
-}
+apply plugin: 'com.palantir.git-version'
 
 repositories {
     jcenter()
@@ -83,5 +67,6 @@ subprojects {
 
     tasks.withType(JavaCompile) {
         options.compilerArgs += ['-Xlint:deprecation', '-Werror']
+        options.errorprone.errorproneArgs += '-Xep:Finally:OFF'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,24 @@ buildscript {
 }
 
 apply plugin: 'com.palantir.git-version'
-apply plugin: 'com.palantir.baseline'
+
 apply plugin: 'com.palantir.consistent-versions'
+
+// expanded version of 'com.palantir.baseline' because errorprone doesn't work on Java12 yet
+apply plugin: 'com.palantir.baseline-config'
+apply plugin: 'com.palantir.baseline-circleci'
+allprojects {
+    apply plugin: 'com.palantir.baseline-checkstyle'
+    apply plugin: 'com.palantir.baseline-scalastyle'
+    apply plugin: 'com.palantir.baseline-eclipse'
+    apply plugin: 'com.palantir.baseline-idea'
+    // apply plugin: 'com.palantir.baseline-error-prone'
+    // apply plugin: 'com.palantir.baseline-versions'
+    apply plugin: 'com.palantir.baseline-format'
+    apply plugin: 'com.palantir.baseline-reproducibility'
+    apply plugin: 'com.palantir.baseline-exact-dependencies'
+    apply plugin: 'com.palantir.baseline-release-compatibility'
+}
 
 repositories {
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,8 @@ subprojects {
 
     tasks.withType(JavaCompile) {
         options.compilerArgs += ['-Xlint:deprecation', '-Werror']
+
+        // necessary until https://github.com/google/error-prone/pull/1107
         options.errorprone.errorproneArgs += '-Xep:Finally:OFF'
     }
 }


### PR DESCRIPTION
Internally, we're pushing all our services to run on Java11 _only_ as it's a nice LTS release.

For _libraries_ however, we want to keep testing against Java8 to make sure we don't break backwards compatibility. Given we have to keep the java 8 CI, I think we might as well start testing against Java 12, so hopefully we can catch any tooling gotchas early.

cc @robert3005 