### PR TITLE
[improvement] Add sampled-state to filters

### DIFF
--- a/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
+++ b/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
@@ -42,6 +42,7 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
      * This is the name of the trace id property we set on {@link ContainerRequestContext}.
      */
     public static final String TRACE_ID_PROPERTY_NAME = "com.palantir.tracing.traceId";
+    public static final String SAMPLED_PROPERTY_NAME = "com.palantir.tracing.sampled";
 
     @Context
     private ExtendedUriInfo uriInfo;
@@ -76,6 +77,7 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
 
         // Give asynchronous downstream handlers access to the trace id
         requestContext.setProperty(TRACE_ID_PROPERTY_NAME, Tracer.getTraceId());
+        requestContext.setProperty(SAMPLED_PROPERTY_NAME, Tracer.isTraceObservable());
     }
 
     // Handles outgoing response

--- a/tracing-jersey/src/test/java/com/palantir/tracing/jersey/TraceEnrichingFilterTest.java
+++ b/tracing-jersey/src/test/java/com/palantir/tracing/jersey/TraceEnrichingFilterTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -220,6 +221,8 @@ public final class TraceEnrichingFilterTest {
         TraceEnrichingFilter.INSTANCE.filter(request);
         assertThat(MDC.get(Tracers.TRACE_ID_KEY), is("traceId"));
         verify(request).setProperty(TraceEnrichingFilter.TRACE_ID_PROPERTY_NAME, "traceId");
+        // Note: this will be set to a random value; we want to check whether the value is being set
+        verify(request).setProperty(eq(TraceEnrichingFilter.SAMPLED_PROPERTY_NAME), anyBoolean());
     }
 
     @Test

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
@@ -25,6 +25,7 @@ import com.palantir.tracing.api.SpanType;
 import com.palantir.tracing.api.TraceHttpHeaders;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.util.AttachmentKey;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.HttpString;
 import java.util.Optional;
@@ -40,10 +41,15 @@ import java.util.Optional;
  * that handler may register.
  */
 public final class TracedOperationHandler implements HttpHandler {
+    /**
+     * Attachment to check whether the current request is being traced.
+     */
+    public static final AttachmentKey<Boolean> IS_SAMPLED_ATTACHMENT = AttachmentKey.create(Boolean.class);
 
     private static final HttpString TRACE_ID = HttpString.tryFromString(TraceHttpHeaders.TRACE_ID);
     private static final HttpString SPAN_ID = HttpString.tryFromString(TraceHttpHeaders.SPAN_ID);
     private static final HttpString IS_SAMPLED = HttpString.tryFromString(TraceHttpHeaders.IS_SAMPLED);
+
 
     // Pre-compute sampled values, there's no need to do this work for each request
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
@@ -62,11 +68,10 @@ public final class TracedOperationHandler implements HttpHandler {
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         String traceId = initializeTrace(exchange);
-        String sampled = Tracer.isTraceObservable() ? "1" : "0";
 
         // Populate response before calling delegate since delegate might commit the response.
         exchange.getResponseHeaders().put(TRACE_ID, traceId);
-        exchange.getResponseHeaders().put(IS_SAMPLED, sampled);
+        exchange.putAttachment(IS_SAMPLED_ATTACHMENT, Tracer.isTraceObservable());
         try {
             delegate.handleRequest(exchange);
         } finally {

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
@@ -62,8 +62,11 @@ public final class TracedOperationHandler implements HttpHandler {
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         String traceId = initializeTrace(exchange);
+        String sampled = Tracer.isTraceObservable() ? "1" : "0";
+
         // Populate response before calling delegate since delegate might commit the response.
         exchange.getResponseHeaders().put(TRACE_ID, traceId);
+        exchange.getResponseHeaders().put(IS_SAMPLED, sampled);
         try {
             delegate.handleRequest(exchange);
         } finally {

--- a/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedOperationHandlerTest.java
+++ b/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedOperationHandlerTest.java
@@ -130,6 +130,22 @@ public class TracedOperationHandlerTest {
     }
 
     @Test
+    public void whenTraceIsAlreadySampled_setsAttachment() throws Exception {
+        exchange.getRequestHeaders().put(HttpString.tryFromString(TraceHttpHeaders.IS_SAMPLED), "1");
+        handler.handleRequest(exchange);
+
+        assertThat(exchange.getAttachment(TracedOperationHandler.IS_SAMPLED_ATTACHMENT)).isEqualTo(true);
+    }
+
+    @Test
+    public void whenTraceIsAlreadyNotSampled_setsAttachment() throws Exception {
+        exchange.getRequestHeaders().put(HttpString.tryFromString(TraceHttpHeaders.IS_SAMPLED), "0");
+        handler.handleRequest(exchange);
+
+        assertThat(exchange.getAttachment(TracedOperationHandler.IS_SAMPLED_ATTACHMENT)).isEqualTo(false);
+    }
+
+    @Test
     public void whenSamplingDecisionHasNotBeenMade_callsSampler() throws Exception {
         handler.handleRequest(exchange);
         verify(traceSampler).sample();


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
The jetty filter doesn't add the sampled state of the trace the request context.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
The jetty filter adds the sampled state to the request context, enabling e.g. logging to mark sampled traces for later inspection/filtering.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
