### PR TITLE
[improvement] Use java Instant to set startTimeMicroSeconds

### DIFF
--- a/tracing-api/src/main/java/com/palantir/tracing/api/OpenSpan.java
+++ b/tracing-api/src/main/java/com/palantir/tracing/api/OpenSpan.java
@@ -16,6 +16,7 @@
 
 package com.palantir.tracing.api;
 
+import java.time.Instant;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -71,8 +72,13 @@ public abstract class OpenSpan {
     public static Builder builder() {
         return new Builder()
                 // TODO(rfink): Use direct access to system microseconds when moving to Java8 / Java9
-                .startTimeMicroSeconds(System.currentTimeMillis() * 1000)
+                .startTimeMicroSeconds(getNowInMicroSeconds())
                 .startClockNanoSeconds(System.nanoTime());
+    }
+
+    private static long getNowInMicroSeconds() {
+        Instant now = Instant.now();
+        return (1000000 * now.getEpochSecond()) + (now.getNano() / 1000);
     }
 
     public static class Builder extends ImmutableOpenSpan.Builder {}

--- a/tracing-api/src/main/java/com/palantir/tracing/api/OpenSpan.java
+++ b/tracing-api/src/main/java/com/palantir/tracing/api/OpenSpan.java
@@ -16,6 +16,7 @@
 
 package com.palantir.tracing.api;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.util.Optional;
 import org.immutables.value.Value;
@@ -27,6 +28,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
 public abstract class OpenSpan {
+    private static final Clock CLOCK = Clock.systemUTC();
 
     /**
      * Returns a description of the operation for this event.
@@ -71,13 +73,12 @@ public abstract class OpenSpan {
      */
     public static Builder builder() {
         return new Builder()
-                // TODO(rfink): Use direct access to system microseconds when moving to Java8 / Java9
                 .startTimeMicroSeconds(getNowInMicroSeconds())
                 .startClockNanoSeconds(System.nanoTime());
     }
 
     private static long getNowInMicroSeconds() {
-        Instant now = Instant.now();
+        Instant now = CLOCK.instant();
         return (1000000 * now.getEpochSecond()) + (now.getNano() / 1000);
     }
 

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -29,6 +29,7 @@ import com.palantir.tracing.api.OpenSpan;
 import com.palantir.tracing.api.Span;
 import com.palantir.tracing.api.SpanObserver;
 import com.palantir.tracing.api.SpanType;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -67,6 +68,13 @@ public final class TracerTest {
         Tracer.unsubscribe("1");
         Tracer.unsubscribe("2");
         Tracer.getAndClearTrace();
+    }
+
+    @Test
+    public void foo() {
+        Instant now = Instant.now();
+        long epochMicros = 1000000 * now.getEpochSecond() + now.getNano() / 1000;
+        System.out.println(Instant.ofEpochMilli(epochMicros / 1000));
     }
 
     @Test

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -29,7 +29,6 @@ import com.palantir.tracing.api.OpenSpan;
 import com.palantir.tracing.api.Span;
 import com.palantir.tracing.api.SpanObserver;
 import com.palantir.tracing.api.SpanType;
-import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -68,13 +67,6 @@ public final class TracerTest {
         Tracer.unsubscribe("1");
         Tracer.unsubscribe("2");
         Tracer.getAndClearTrace();
-    }
-
-    @Test
-    public void foo() {
-        Instant now = Instant.now();
-        long epochMicros = 1000000 * now.getEpochSecond() + now.getNano() / 1000;
-        System.out.println(Instant.ofEpochMilli(epochMicros / 1000));
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
`startTimeMicroSeconds` is set using `System.currentTimeMillis()`, which only gives millisecond granularity

## After this PR
`startTimeMicroSeconds` is set using `Instant.now()`. On Java 8 it still only gives millisecond granularity, but it gives microsecond granularity in java 11.

## Concerns
I am assuming it is fair game to use Java 8 classes in this repo