### PR TITLE
[proposal] Allow creating deferred traces without spans

### DIFF
--- a/tracing-jaxrs/src/test/java/com/palantir/tracing/jaxrs/JaxRsTracersTest.java
+++ b/tracing-jaxrs/src/test/java/com/palantir/tracing/jaxrs/JaxRsTracersTest.java
@@ -19,6 +19,7 @@ package com.palantir.tracing.jaxrs;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.tracing.Tracer;
+import com.palantir.tracing.api.Span;
 import java.io.ByteArrayOutputStream;
 import javax.ws.rs.core.StreamingOutput;
 import org.junit.Test;
@@ -37,9 +38,11 @@ public final class JaxRsTracersTest {
 
     @Test
     public void testWrappingStreamingOutput_traceStateIsCapturedAtConstructionTime() throws Exception {
-        Tracer.startSpan("before-construction");
+        String beforeSpanId = Tracer.startSpan("before-construction").getSpanId();
         StreamingOutput streamingOutput = JaxRsTracers.wrap(os -> {
-            assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("streaming-output");
+            Span span = Tracer.completeSpan().get();
+            assertThat(span.getOperation()).isEqualTo("streaming-output");
+            assertThat(span.getParentSpanId()).contains(beforeSpanId);
         });
         Tracer.startSpan("after-construction");
         streamingOutput.write(new ByteArrayOutputStream());

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -130,10 +130,10 @@ public final class Tracer {
                 .type(type);
 
         Trace trace = getOrCreateCurrentTrace();
-        Optional<OpenSpan> prevState = trace.top();
+        Optional<String> parentSpanId = trace.topSpanId();
         // Avoid lambda allocation in hot paths
-        if (prevState.isPresent()) {
-            spanBuilder.parentSpanId(prevState.get().getSpanId());
+        if (parentSpanId.isPresent()) {
+            spanBuilder.parentSpanId(parentSpanId.get());
         }
 
         OpenSpan span = spanBuilder.build();


### PR DESCRIPTION
This PR probably should not be merged in the current form but instead should be replaced by a more appropriate API. The purpose of this PR is to facilitate a discussion about how best to support this behavior.

At the very least, this use case should be taken into consideration in https://github.com/palantir/tracing-java/pull/124.

## Before this PR
It was not possible to create a wrapped runnable/callable/executor that did not create a new span for the task being run. This behavior used to be optional, but it was made mandatory in #97. While ideally, we want every deferred task to have a span, this can cause ergonomic issues when chaining asynchronous tasks.

For example, when chaining multiple futures:
```
FluentFuture.from(future)
    .transform(result -> handleResult1(...), wrappedExecutor)
    .transform(result -> handleResult2(...), wrappedExecutor)
```

Each executor tasks submits the callback inside it's own task. This results in nested executor spans as deep as the callback chain. For the above example, the spans would look like:
```
parentSpan
|-- executor
    |-- handleResult1
    |-- executor
         |-- handleResult2
```

In this case, it would be preferable to have an executor that did not wrap tasks in a new span.

## After this PR
`DeferredTracer` allows running tasks that will not create a new containing span.

For the above example, the spans would now look like:
```
parentSpan
|-- handleResult1
|-- handleResult2
```
