### PR TITLE
[improvement] Set the default sampler to random with 1%

### DIFF
--- a/tracing-okhttp3/src/test/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptorTest.java
+++ b/tracing-okhttp3/src/test/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptorTest.java
@@ -105,6 +105,7 @@ public final class OkhttpTraceInterceptorTest {
 
     @Test
     public void testAddsIsSampledHeader_whenTraceIsObservable() throws IOException {
+        Tracer.initTrace(Optional.of(true), Tracers.randomId());
         OkhttpTraceInterceptor.INSTANCE.intercept(chain);
         verify(chain).proceed(requestCaptor.capture());
         assertThat(requestCaptor.getValue().header(TraceHttpHeaders.IS_SAMPLED)).isEqualTo("1");

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -59,7 +59,7 @@ public final class Tracer {
     private static volatile Consumer<Span> compositeObserver = span -> { };
 
     // Thread-safe since stateless
-    private static volatile TraceSampler sampler = AlwaysSampler.INSTANCE;
+    private static volatile TraceSampler sampler = new RandomSampler(0.01f);
 
     /**
      * Creates a new trace, but does not set it as the current trace. The new trace is {@link Trace#isObservable

--- a/tracing/src/test/java/com/palantir/tracing/AsyncSlf4jSpanObserverTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/AsyncSlf4jSpanObserverTest.java
@@ -39,6 +39,7 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import org.jmock.lib.concurrent.DeterministicScheduler;
@@ -98,6 +99,7 @@ public final class AsyncSlf4jSpanObserverTest {
         DeterministicScheduler executor = new DeterministicScheduler();
         Tracer.subscribe(TEST_OBSERVER, AsyncSlf4jSpanObserver.of(
                 "serviceName", Inet4Address.getLoopbackAddress(), logger, executor));
+        Tracer.initTrace(Optional.of(true), Tracers.randomId());
         Tracer.startSpan("operation");
         Span span = Tracer.completeSpan().get();
         verify(appender, never()).doAppend(any(ILoggingEvent.class)); // async logger only fires when executor runs
@@ -118,6 +120,7 @@ public final class AsyncSlf4jSpanObserverTest {
     public void testDefaultConstructorDeterminesIpAddress() throws Exception {
         DeterministicScheduler executor = new DeterministicScheduler();
         Tracer.subscribe(TEST_OBSERVER, AsyncSlf4jSpanObserver.of("serviceName", executor));
+        Tracer.initTrace(Optional.of(true), Tracers.randomId());
         Tracer.startSpan("operation");
         Span span = Tracer.completeSpan().get();
 

--- a/tracing/src/test/java/com/palantir/tracing/AsyncTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/AsyncTracerTest.java
@@ -42,7 +42,8 @@ public class AsyncTracerTest {
 
     @Test
     public void completesBothDeferredSpans() {
-        Tracer.initTrace(Optional.empty(), "defaultTraceId");
+        Tracer.initTrace(Optional.of(true), "defaultTraceId");
+        Tracer.startSpan("defaultSpan");
         AsyncTracer asyncTracer = new AsyncTracer();
         List<String> observedSpans = Lists.newArrayList();
         Tracer.subscribe(


### PR DESCRIPTION
## Before this PR
The default sampler would sample all traces. I would claim this is not a great default and is somewhat error prone. It expects all consumers to override it to an appropriate value, with the penalty to failing to doing so being a high number of tracing logs that puts a lot of pressure in logging pipelines.

## After this PR
The default sampler is random with 1% probability of sampling.