### PR TITLE
[improvement] Allow setting observable flag when wrapping with new trace

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -217,19 +217,24 @@ public final class Tracers {
         return wrapWithNewTrace(DEFAULT_ROOT_SPAN_OPERATION, delegate);
     }
 
+    public static <V> Callable<V> wrapWithNewTrace(String operation, Callable<V> delegate) {
+        return wrapWithNewTrace(operation, delegate, Observability.UNDECIDED);
+    }
+
     /**
      * Wraps the given {@link Callable} such that it creates a fresh {@link Trace tracing state} for its execution.
      * That is, the trace during its {@link Callable#call() execution} is entirely separate from the trace at
      * construction or any trace already set on the thread used to execute the callable. Each execution of the callable
      * will have a fresh trace. The given {@link String operation} is used to create the initial span.
      */
-    public static <V> Callable<V> wrapWithNewTrace(String operation, Callable<V> delegate) {
+    public static <V> Callable<V> wrapWithNewTrace(String operation, Callable<V> delegate,
+            Observability observability) {
         return () -> {
             // clear the existing trace and keep it around for restoration when we're done
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
-                Tracer.initTrace(Observability.UNDECIDED, Tracers.randomId());
+                Tracer.initTrace(observability, Tracers.randomId());
                 Tracer.startSpan(operation);
                 return delegate.call();
             } finally {
@@ -249,19 +254,23 @@ public final class Tracers {
         return wrapWithNewTrace(DEFAULT_ROOT_SPAN_OPERATION, delegate);
     }
 
+    public static Runnable wrapWithNewTrace(String operation, Runnable delegate) {
+        return wrapWithNewTrace(operation, delegate, Observability.UNDECIDED);
+    }
+
     /**
      * Wraps the given {@link Runnable} such that it creates a fresh {@link Trace tracing state} for its execution.
      * That is, the trace during its {@link Runnable#run() execution} is entirely separate from the trace at
      * construction or any trace already set on the thread used to execute the runnable. Each execution of the runnable
      * will have a fresh trace. The given {@link String operation} is used to create the initial span.
      */
-    public static Runnable wrapWithNewTrace(String operation, Runnable delegate) {
+    public static Runnable wrapWithNewTrace(String operation, Runnable delegate, Observability observability) {
         return () -> {
             // clear the existing trace and keep it around for restoration when we're done
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
-                Tracer.initTrace(Observability.UNDECIDED, Tracers.randomId());
+                Tracer.initTrace(observability, Tracers.randomId());
                 Tracer.startSpan(operation);
                 delegate.run();
             } finally {
@@ -281,6 +290,10 @@ public final class Tracers {
         return wrapWithAlternateTraceId(traceId, DEFAULT_ROOT_SPAN_OPERATION, delegate);
     }
 
+    public static Runnable wrapWithAlternateTraceId(String traceId, String operation, Runnable delegate) {
+        return wrapWithAlternateTraceId(traceId, operation, delegate, Observability.UNDECIDED);
+    }
+
     /**
      * Wraps the given {@link Runnable} such that it creates a fresh {@link Trace tracing state with the given traceId}
      * for its execution. That is, the trace during its {@link Runnable#run() execution} will use the traceId provided
@@ -288,14 +301,14 @@ public final class Tracers {
      * will use a new {@link Trace tracing state} with the same given traceId.  The given {@link String operation} is
      * used to create the initial span.
      */
-    public static Runnable wrapWithAlternateTraceId(String traceId, String operation, Runnable
-            delegate) {
+    public static Runnable wrapWithAlternateTraceId(String traceId, String operation, Runnable delegate,
+            Observability observability) {
         return () -> {
             // clear the existing trace and keep it around for restoration when we're done
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
-                Tracer.initTrace(Observability.UNDECIDED, traceId);
+                Tracer.initTrace(observability, traceId);
                 Tracer.startSpan(operation);
                 delegate.run();
             } finally {

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -218,7 +218,7 @@ public final class Tracers {
     }
 
     public static <V> Callable<V> wrapWithNewTrace(String operation, Callable<V> delegate) {
-        return wrapWithNewTrace(operation, delegate, Observability.UNDECIDED);
+        return wrapWithNewTrace(operation, Observability.UNDECIDED, delegate);
     }
 
     /**
@@ -227,8 +227,8 @@ public final class Tracers {
      * construction or any trace already set on the thread used to execute the callable. Each execution of the callable
      * will have a fresh trace. The given {@link String operation} is used to create the initial span.
      */
-    public static <V> Callable<V> wrapWithNewTrace(String operation, Callable<V> delegate,
-            Observability observability) {
+    public static <V> Callable<V> wrapWithNewTrace(String operation, Observability observability,
+            Callable<V> delegate) {
         return () -> {
             // clear the existing trace and keep it around for restoration when we're done
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
@@ -255,7 +255,7 @@ public final class Tracers {
     }
 
     public static Runnable wrapWithNewTrace(String operation, Runnable delegate) {
-        return wrapWithNewTrace(operation, delegate, Observability.UNDECIDED);
+        return wrapWithNewTrace(operation, Observability.UNDECIDED, delegate);
     }
 
     /**
@@ -264,7 +264,7 @@ public final class Tracers {
      * construction or any trace already set on the thread used to execute the runnable. Each execution of the runnable
      * will have a fresh trace. The given {@link String operation} is used to create the initial span.
      */
-    public static Runnable wrapWithNewTrace(String operation, Runnable delegate, Observability observability) {
+    public static Runnable wrapWithNewTrace(String operation, Observability observability, Runnable delegate) {
         return () -> {
             // clear the existing trace and keep it around for restoration when we're done
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
@@ -291,7 +291,7 @@ public final class Tracers {
     }
 
     public static Runnable wrapWithAlternateTraceId(String traceId, String operation, Runnable delegate) {
-        return wrapWithAlternateTraceId(traceId, operation, delegate, Observability.UNDECIDED);
+        return wrapWithAlternateTraceId(traceId, operation, Observability.UNDECIDED, delegate);
     }
 
     /**
@@ -301,8 +301,8 @@ public final class Tracers {
      * will use a new {@link Trace tracing state} with the same given traceId.  The given {@link String operation} is
      * used to create the initial span.
      */
-    public static Runnable wrapWithAlternateTraceId(String traceId, String operation, Runnable delegate,
-            Observability observability) {
+    public static Runnable wrapWithAlternateTraceId(String traceId, String operation, Observability observability,
+            Runnable delegate) {
         return () -> {
             // clear the existing trace and keep it around for restoration when we're done
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
`Tracer.wrapWithNewTrace` and `Tracer.wrapWithAlternateTraceId` always initializes the new trace with `Observability.UNDECIDED`, and there is no easy way to force a particular trace to be sampled.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
Added overloaded versions of `wrapWithNewTrace` and `wrapWithAlternateTraceId` that take an additional parameter to allow users to set whether the new trace should be observable.
<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->

This is useful to us because we have a service that makes requests to two separate backends, one of which is wrapped using `wrapWithNewTrace` so that it generates a separate trace, and we want the secondary trace to be sampled when the primary trace is sampled in order to compare the traces. This should become possible with this PR and https://github.com/palantir/tracing-java/pull/164.