### PR TITLE
[improvement] Refactor Tracer.initTrace to take enum instead of optional boolean

### DIFF
--- a/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
+++ b/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
@@ -102,7 +102,8 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
         }
     }
 
-    // Returns true iff the context contains a "1" X-B3-Sampled header, or absent if there is no such header.
+    // Force sample iff the context contains a "1" X-B3-Sampled header, force not sample if the header contains another
+    // non-empty value, or undecided if there is no such header or the header is empty.
     private static Observability getObservabilityFromHeader(ContainerRequestContext context) {
         String header = context.getHeaderString(TraceHttpHeaders.IS_SAMPLED);
         if (Strings.isNullOrEmpty(header)) {

--- a/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
+++ b/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
@@ -106,7 +106,7 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
     private static Observability getObservabilityFromHeader(ContainerRequestContext context) {
         String header = context.getHeaderString(TraceHttpHeaders.IS_SAMPLED);
         if (header == null) {
-            return Observability.SAMPLER_DECIDES;
+            return Observability.UNDECIDED;
         } else {
             return header.equals("1") ? Observability.SAMPLE : Observability.DO_NOT_SAMPLE;
         }

--- a/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
+++ b/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
@@ -105,10 +105,10 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
     // Returns true iff the context contains a "1" X-B3-Sampled header, or absent if there is no such header.
     private static Observability getObservabilityFromHeader(ContainerRequestContext context) {
         String header = context.getHeaderString(TraceHttpHeaders.IS_SAMPLED);
-        if (header == null) {
+        if (Strings.isNullOrEmpty(header)) {
             return Observability.UNDECIDED;
         } else {
-            return header.equals("1") ? Observability.SAMPLE : Observability.DO_NOT_SAMPLE;
+            return "1".equals(header) ? Observability.SAMPLE : Observability.DO_NOT_SAMPLE;
         }
     }
 }

--- a/tracing-okhttp3/src/test/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptorTest.java
+++ b/tracing-okhttp3/src/test/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.palantir.tracing.Observability;
 import com.palantir.tracing.Tracer;
 import com.palantir.tracing.Tracers;
 import com.palantir.tracing.api.OpenSpan;
@@ -30,7 +31,6 @@ import com.palantir.tracing.api.SpanObserver;
 import com.palantir.tracing.api.SpanType;
 import com.palantir.tracing.api.TraceHttpHeaders;
 import java.io.IOException;
-import java.util.Optional;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import org.junit.After;
@@ -65,7 +65,7 @@ public final class OkhttpTraceInterceptorTest {
 
     @After
     public void after() {
-        Tracer.initTrace(Optional.of(true), Tracers.randomId());
+        Tracer.initTrace(Observability.SAMPLE, Tracers.randomId());
         Tracer.unsubscribe("");
     }
 
@@ -105,7 +105,7 @@ public final class OkhttpTraceInterceptorTest {
 
     @Test
     public void testAddsIsSampledHeader_whenTraceIsObservable() throws IOException {
-        Tracer.initTrace(Optional.of(true), Tracers.randomId());
+        Tracer.initTrace(Observability.SAMPLE, Tracers.randomId());
         OkhttpTraceInterceptor.INSTANCE.intercept(chain);
         verify(chain).proceed(requestCaptor.capture());
         assertThat(requestCaptor.getValue().header(TraceHttpHeaders.IS_SAMPLED)).isEqualTo("1");
@@ -113,7 +113,7 @@ public final class OkhttpTraceInterceptorTest {
 
     @Test
     public void testHeaders_whenTraceIsNotObservable() throws IOException {
-        Tracer.initTrace(Optional.of(false), Tracers.randomId());
+        Tracer.initTrace(Observability.DO_NOT_SAMPLE, Tracers.randomId());
         String traceId = Tracer.getTraceId();
         OkhttpTraceInterceptor.INSTANCE.intercept(chain);
         verify(chain).proceed(requestCaptor.capture());

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
@@ -72,14 +72,14 @@ public final class TracedOperationHandler implements HttpHandler {
         }
     }
 
-    // Returns true iff the context contains a "1" X-B3-Sampled header, false if the header contains another value,
-    // or absent if there is no such header.
+    // Force sample iff the context contains a "1" X-B3-Sampled header, force not sample if the header contains another
+    // non-empty value, or undecided if there is no such header or the header is empty.
     private static Observability getObservabilityFromHeader(HeaderMap headers) {
         String header = headers.getFirst(IS_SAMPLED);
-        if (header == null) {
+        if (Strings.isNullOrEmpty(header)) {
             return Observability.UNDECIDED;
         } else {
-            return header.equals("1") ? Observability.SAMPLE : Observability.DO_NOT_SAMPLE;
+            return "1".equals(header) ? Observability.SAMPLE : Observability.DO_NOT_SAMPLE;
         }
     }
 

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
@@ -79,8 +79,6 @@ public final class TracedOperationHandler implements HttpHandler {
         if (header == null) {
             return Observability.SAMPLER_DECIDES;
         } else {
-            // No need to box the resulting boolean and allocate
-            // a new Optional wrapper for each invocation.
             return header.equals("1") ? Observability.SAMPLE : Observability.DO_NOT_SAMPLE;
         }
     }

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
@@ -77,7 +77,7 @@ public final class TracedOperationHandler implements HttpHandler {
     private static Observability getObservabilityFromHeader(HeaderMap headers) {
         String header = headers.getFirst(IS_SAMPLED);
         if (header == null) {
-            return Observability.SAMPLER_DECIDES;
+            return Observability.UNDECIDED;
         } else {
             return header.equals("1") ? Observability.SAMPLE : Observability.DO_NOT_SAMPLE;
         }

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
@@ -19,6 +19,7 @@ package com.palantir.tracing.undertow;
 import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.google.common.base.Strings;
+import com.palantir.tracing.Observability;
 import com.palantir.tracing.Tracer;
 import com.palantir.tracing.Tracers;
 import com.palantir.tracing.api.SpanType;
@@ -28,7 +29,6 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.AttachmentKey;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.HttpString;
-import java.util.Optional;
 
 /**
  * Extracts Zipkin-style trace information from the given HTTP request and sets up a corresponding
@@ -49,13 +49,6 @@ public final class TracedOperationHandler implements HttpHandler {
     private static final HttpString TRACE_ID = HttpString.tryFromString(TraceHttpHeaders.TRACE_ID);
     private static final HttpString SPAN_ID = HttpString.tryFromString(TraceHttpHeaders.SPAN_ID);
     private static final HttpString IS_SAMPLED = HttpString.tryFromString(TraceHttpHeaders.IS_SAMPLED);
-
-
-    // Pre-compute sampled values, there's no need to do this work for each request
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private static final Optional<Boolean> SAMPLED = Optional.of(Boolean.TRUE);
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private static final Optional<Boolean> NOT_SAMPLED = Optional.of(Boolean.FALSE);
 
     private final String operation;
     private final HttpHandler delegate;
@@ -81,14 +74,14 @@ public final class TracedOperationHandler implements HttpHandler {
 
     // Returns true iff the context contains a "1" X-B3-Sampled header, false if the header contains another value,
     // or absent if there is no such header.
-    private static Optional<Boolean> hasSampledHeader(HeaderMap headers) {
+    private static Observability getObservabilityFromHeader(HeaderMap headers) {
         String header = headers.getFirst(IS_SAMPLED);
         if (header == null) {
-            return Optional.empty();
+            return Observability.SAMPLER_DECIDES;
         } else {
             // No need to box the resulting boolean and allocate
             // a new Optional wrapper for each invocation.
-            return header.equals("1") ? SAMPLED : NOT_SAMPLED;
+            return header.equals("1") ? Observability.SAMPLE : Observability.DO_NOT_SAMPLE;
         }
     }
 
@@ -109,7 +102,7 @@ public final class TracedOperationHandler implements HttpHandler {
 
     /** Initializes trace state given a trace-id header from the client. */
     private void initializeTraceFromExisting(HeaderMap headers, String traceId) {
-        Tracer.initTrace(hasSampledHeader(headers), traceId);
+        Tracer.initTrace(getObservabilityFromHeader(headers), traceId);
         String spanId = headers.getFirst(SPAN_ID); // nullable
         if (spanId == null) {
             Tracer.startSpan(operation, SpanType.SERVER_INCOMING);
@@ -123,7 +116,7 @@ public final class TracedOperationHandler implements HttpHandler {
     private String initializeNewTrace(HeaderMap headers) {
         // HTTP request did not indicate a trace; initialize trace state and create a span.
         String newTraceId = Tracers.randomId();
-        Tracer.initTrace(hasSampledHeader(headers), newTraceId);
+        Tracer.initTrace(getObservabilityFromHeader(headers), newTraceId);
         Tracer.startSpan(operation, SpanType.SERVER_INCOMING);
         return newTraceId;
     }

--- a/tracing/src/main/java/com/palantir/tracing/Observability.java
+++ b/tracing/src/main/java/com/palantir/tracing/Observability.java
@@ -1,0 +1,23 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tracing;
+
+public enum Observability {
+    SAMPLE,
+    DO_NOT_SAMPLE,
+    SAMPLER_DECIDES
+}

--- a/tracing/src/main/java/com/palantir/tracing/Observability.java
+++ b/tracing/src/main/java/com/palantir/tracing/Observability.java
@@ -19,5 +19,5 @@ package com.palantir.tracing;
 public enum Observability {
     SAMPLE,
     DO_NOT_SAMPLE,
-    SAMPLER_DECIDES
+    UNDECIDED
 }

--- a/tracing/src/main/java/com/palantir/tracing/Observability.java
+++ b/tracing/src/main/java/com/palantir/tracing/Observability.java
@@ -16,8 +16,22 @@
 
 package com.palantir.tracing;
 
+/**
+ * Represents the desired observability of a new trace.
+ */
 public enum Observability {
+    /**
+     * Force the trace to be sampled.
+     */
     SAMPLE,
+
+    /**
+     * Force the trace to not be sampled.
+     */
     DO_NOT_SAMPLE,
+
+    /**
+     * Do not force, and let the tracer decide the observability.
+     */
     UNDECIDED
 }

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -85,6 +85,20 @@ public final class Tracer {
     }
 
     /**
+     * Deprecated.
+     *
+     * @deprecated Use {@link #initTrace(Observability, String)}
+     */
+    @Deprecated
+    public static void initTrace(Optional<Boolean> isObservable, String traceId) {
+        Observability observability = isObservable
+                .map(value -> Boolean.TRUE.equals(value) ? Observability.SAMPLE : Observability.DO_NOT_SAMPLE)
+                .orElse(Observability.SAMPLER_DECIDES);
+
+        setTrace(createTrace(observability, traceId));
+    }
+
+    /**
      * Initializes the current thread's trace, erasing any previously accrued open spans.
      */
     public static void initTrace(Observability observability, String traceId) {

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -77,7 +77,7 @@ public final class Tracer {
                 return true;
             case DO_NOT_SAMPLE:
                 return false;
-            case SAMPLER_DECIDES:
+            case UNDECIDED:
                 return sampler.sample();
         }
 
@@ -93,7 +93,7 @@ public final class Tracer {
     public static void initTrace(Optional<Boolean> isObservable, String traceId) {
         Observability observability = isObservable
                 .map(value -> Boolean.TRUE.equals(value) ? Observability.SAMPLE : Observability.DO_NOT_SAMPLE)
-                .orElse(Observability.SAMPLER_DECIDES);
+                .orElse(Observability.UNDECIDED);
 
         setTrace(createTrace(observability, traceId));
     }
@@ -371,7 +371,7 @@ public final class Tracer {
     private static Trace getOrCreateCurrentTrace() {
         Trace trace = currentTrace.get();
         if (trace == null) {
-            trace = createTrace(Observability.SAMPLER_DECIDES, Tracers.randomId());
+            trace = createTrace(Observability.UNDECIDED, Tracers.randomId());
             setTrace(trace);
         }
         return trace;

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -229,7 +229,7 @@ public final class Tracers {
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
-                Tracer.initTrace(Optional.empty(), Tracers.randomId());
+                Tracer.initTrace(Observability.SAMPLER_DECIDES, Tracers.randomId());
                 Tracer.startSpan(operation);
                 return delegate.call();
             } finally {
@@ -261,7 +261,7 @@ public final class Tracers {
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
-                Tracer.initTrace(Optional.empty(), Tracers.randomId());
+                Tracer.initTrace(Observability.SAMPLER_DECIDES, Tracers.randomId());
                 Tracer.startSpan(operation);
                 delegate.run();
             } finally {
@@ -295,7 +295,7 @@ public final class Tracers {
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
-                Tracer.initTrace(Optional.empty(), traceId);
+                Tracer.initTrace(Observability.SAMPLER_DECIDES, traceId);
                 Tracer.startSpan(operation);
                 delegate.run();
             } finally {

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -229,7 +229,7 @@ public final class Tracers {
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
-                Tracer.initTrace(Observability.SAMPLER_DECIDES, Tracers.randomId());
+                Tracer.initTrace(Observability.UNDECIDED, Tracers.randomId());
                 Tracer.startSpan(operation);
                 return delegate.call();
             } finally {
@@ -261,7 +261,7 @@ public final class Tracers {
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
-                Tracer.initTrace(Observability.SAMPLER_DECIDES, Tracers.randomId());
+                Tracer.initTrace(Observability.UNDECIDED, Tracers.randomId());
                 Tracer.startSpan(operation);
                 delegate.run();
             } finally {
@@ -295,7 +295,7 @@ public final class Tracers {
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
-                Tracer.initTrace(Observability.SAMPLER_DECIDES, traceId);
+                Tracer.initTrace(Observability.UNDECIDED, traceId);
                 Tracer.startSpan(operation);
                 delegate.run();
             } finally {

--- a/tracing/src/test/java/com/palantir/tracing/AsyncSlf4jSpanObserverTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/AsyncSlf4jSpanObserverTest.java
@@ -39,7 +39,6 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import org.jmock.lib.concurrent.DeterministicScheduler;
@@ -99,7 +98,7 @@ public final class AsyncSlf4jSpanObserverTest {
         DeterministicScheduler executor = new DeterministicScheduler();
         Tracer.subscribe(TEST_OBSERVER, AsyncSlf4jSpanObserver.of(
                 "serviceName", Inet4Address.getLoopbackAddress(), logger, executor));
-        Tracer.initTrace(Optional.of(true), Tracers.randomId());
+        Tracer.initTrace(Observability.SAMPLE, Tracers.randomId());
         Tracer.startSpan("operation");
         Span span = Tracer.completeSpan().get();
         verify(appender, never()).doAppend(any(ILoggingEvent.class)); // async logger only fires when executor runs
@@ -120,7 +119,7 @@ public final class AsyncSlf4jSpanObserverTest {
     public void testDefaultConstructorDeterminesIpAddress() throws Exception {
         DeterministicScheduler executor = new DeterministicScheduler();
         Tracer.subscribe(TEST_OBSERVER, AsyncSlf4jSpanObserver.of("serviceName", executor));
-        Tracer.initTrace(Optional.of(true), Tracers.randomId());
+        Tracer.initTrace(Observability.SAMPLE, Tracers.randomId());
         Tracer.startSpan("operation");
         Span span = Tracer.completeSpan().get();
 

--- a/tracing/src/test/java/com/palantir/tracing/AsyncTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/AsyncTracerTest.java
@@ -20,13 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Lists;
 import java.util.List;
-import java.util.Optional;
 import org.junit.Test;
 
 public class AsyncTracerTest {
     @Test
     public void doesNotLeakEnqueueSpan() {
-        Tracer.initTrace(Optional.empty(), "defaultTraceId");
+        Tracer.initTrace(Observability.SAMPLER_DECIDES, "defaultTraceId");
         Trace originalTrace = getTrace();
         AsyncTracer deferredTracer = new AsyncTracer();
         assertThat(originalTrace.top()).isEmpty();
@@ -42,7 +41,7 @@ public class AsyncTracerTest {
 
     @Test
     public void completesBothDeferredSpans() {
-        Tracer.initTrace(Optional.of(true), "defaultTraceId");
+        Tracer.initTrace(Observability.SAMPLE, "defaultTraceId");
         Tracer.startSpan("defaultSpan");
         AsyncTracer asyncTracer = new AsyncTracer();
         List<String> observedSpans = Lists.newArrayList();
@@ -57,7 +56,7 @@ public class AsyncTracerTest {
 
     @Test
     public void preservesState() {
-        Tracer.initTrace(Optional.empty(), "defaultTraceId");
+        Tracer.initTrace(Observability.SAMPLER_DECIDES, "defaultTraceId");
         Tracer.startSpan("foo");
         Tracer.startSpan("bar");
         Tracer.startSpan("baz");

--- a/tracing/src/test/java/com/palantir/tracing/AsyncTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/AsyncTracerTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class AsyncTracerTest {
     @Test
     public void doesNotLeakEnqueueSpan() {
-        Tracer.initTrace(Observability.SAMPLER_DECIDES, "defaultTraceId");
+        Tracer.initTrace(Observability.UNDECIDED, "defaultTraceId");
         Trace originalTrace = getTrace();
         AsyncTracer deferredTracer = new AsyncTracer();
         assertThat(originalTrace.top()).isEmpty();
@@ -56,7 +56,7 @@ public class AsyncTracerTest {
 
     @Test
     public void preservesState() {
-        Tracer.initTrace(Observability.SAMPLER_DECIDES, "defaultTraceId");
+        Tracer.initTrace(Observability.UNDECIDED, "defaultTraceId");
         Tracer.startSpan("foo");
         Tracer.startSpan("bar");
         Tracer.startSpan("baz");

--- a/tracing/src/test/java/com/palantir/tracing/DeferredTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/DeferredTracerTest.java
@@ -23,14 +23,13 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.util.Optional;
 import org.junit.Test;
 
 public class DeferredTracerTest {
 
     @Test
     public void testIsSerializable() throws IOException, ClassNotFoundException {
-        Tracer.initTrace(Optional.empty(), "defaultTraceId");
+        Tracer.initTrace(Observability.SAMPLER_DECIDES, "defaultTraceId");
 
         DeferredTracer deferredTracer = new DeferredTracer("operation");
 
@@ -39,7 +38,7 @@ public class DeferredTracerTest {
             objectOutputStream.writeObject(deferredTracer);
         }
 
-        Tracer.initTrace(Optional.empty(), "someOtherTraceId");
+        Tracer.initTrace(Observability.SAMPLER_DECIDES, "someOtherTraceId");
 
         ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
         try (ObjectInputStream objectInputStream = new ObjectInputStream(bais)) {

--- a/tracing/src/test/java/com/palantir/tracing/DeferredTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/DeferredTracerTest.java
@@ -29,7 +29,7 @@ public class DeferredTracerTest {
 
     @Test
     public void testIsSerializable() throws IOException, ClassNotFoundException {
-        Tracer.initTrace(Observability.SAMPLER_DECIDES, "defaultTraceId");
+        Tracer.initTrace(Observability.UNDECIDED, "defaultTraceId");
 
         DeferredTracer deferredTracer = new DeferredTracer("operation");
 
@@ -38,7 +38,7 @@ public class DeferredTracerTest {
             objectOutputStream.writeObject(deferredTracer);
         }
 
-        Tracer.initTrace(Observability.SAMPLER_DECIDES, "someOtherTraceId");
+        Tracer.initTrace(Observability.UNDECIDED, "someOtherTraceId");
 
         ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
         try (ObjectInputStream objectInputStream = new ObjectInputStream(bais)) {

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -71,11 +71,11 @@ public final class TracerTest {
 
     @Test
     public void testIdsMustBeNonNullAndNotEmpty() throws Exception {
-        assertThatLoggableExceptionThrownBy(() -> Tracer.initTrace(Observability.SAMPLER_DECIDES, null))
+        assertThatLoggableExceptionThrownBy(() -> Tracer.initTrace(Observability.UNDECIDED, null))
                 .hasLogMessage("traceId must be non-empty")
                 .hasArgs();
 
-        assertThatLoggableExceptionThrownBy(() -> Tracer.initTrace(Observability.SAMPLER_DECIDES, ""))
+        assertThatLoggableExceptionThrownBy(() -> Tracer.initTrace(Observability.UNDECIDED, ""))
                 .hasLogMessage("traceId must be non-empty")
                 .hasArgs();
 

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -24,7 +24,6 @@ import com.palantir.tracing.api.OpenSpan;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -47,7 +46,7 @@ public final class TracersTest {
         MDC.clear();
 
         // Initialize a new trace for each test
-        Tracer.initTrace(Optional.empty(), "defaultTraceId");
+        Tracer.initTrace(Observability.SAMPLER_DECIDES, "defaultTraceId");
     }
 
     @After

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -46,7 +46,7 @@ public final class TracersTest {
         MDC.clear();
 
         // Initialize a new trace for each test
-        Tracer.initTrace(Observability.SAMPLER_DECIDES, "defaultTraceId");
+        Tracer.initTrace(Observability.UNDECIDED, "defaultTraceId");
     }
 
     @After


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
`Tracer.initTrace` takes a slightly awkward approach to use an optional boolean to represent a tri-state (relevant discussion at https://github.com/palantir/tracing-java/pull/163#discussion_r289059477)

## After this PR
<!-- Describe at a high-level why this approach is better. -->
Added a new version of `Tracer.initTrace` that takes an enum instead of an optional boolean for the observability parameter. The old method that takes an optional is deprecated.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
