### PR TITLE
[improvement] Don't impose DO_NOT_SAMPLE on downstream services

### DIFF
--- a/tracing-okhttp3/src/main/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptor.java
+++ b/tracing-okhttp3/src/main/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptor.java
@@ -46,8 +46,12 @@ public enum OkhttpTraceInterceptor implements Interceptor {
         OpenSpan span = Tracer.startSpan(spanName, SpanType.CLIENT_OUTGOING);
         Request.Builder tracedRequest = request.newBuilder()
                 .addHeader(TraceHttpHeaders.TRACE_ID, Tracer.getTraceId())
-                .addHeader(TraceHttpHeaders.SPAN_ID, span.getSpanId())
-                .addHeader(TraceHttpHeaders.IS_SAMPLED, Tracer.isTraceObservable() ? "1" : "0");
+                .addHeader(TraceHttpHeaders.SPAN_ID, span.getSpanId());
+
+        if (Tracer.isTraceObservable()) {
+            tracedRequest.addHeader(TraceHttpHeaders.IS_SAMPLED, "1");
+        }
+
         if (span.getParentSpanId().isPresent()) {
             tracedRequest.header(TraceHttpHeaders.PARENT_SPAN_ID, span.getParentSpanId().get());
         }

--- a/tracing-okhttp3/src/test/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptorTest.java
+++ b/tracing-okhttp3/src/test/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptorTest.java
@@ -120,7 +120,10 @@ public final class OkhttpTraceInterceptorTest {
         Request intercepted = requestCaptor.getValue();
         assertThat(intercepted.header(TraceHttpHeaders.SPAN_ID)).isNotNull();
         assertThat(intercepted.header(TraceHttpHeaders.TRACE_ID)).isEqualTo(traceId);
-        assertThat(intercepted.header(TraceHttpHeaders.IS_SAMPLED)).isEqualTo("0");
+
+        // intentionally don't send "0" for spans that weren't sampled in this service, so that downstream services
+        // can make the sampling decision for themselves
+        assertThat(intercepted.header(TraceHttpHeaders.IS_SAMPLED)).isNull();
     }
 
     @Test

--- a/tracing/src/main/java/com/palantir/tracing/Observability.java
+++ b/tracing/src/main/java/com/palantir/tracing/Observability.java
@@ -16,22 +16,21 @@
 
 package com.palantir.tracing;
 
+import com.palantir.tracing.api.SpanObserver;
+
 /**
  * Represents the desired observability of a new trace.
  */
 public enum Observability {
     /**
-     * Force the trace to be sampled.
+     * Force the trace to be sampled, i.e.s spans will be sent to each {@link SpanObserver}, and any outgoing
+     * network requests will have the X-B3-SAMPLED header set to "1", so that all downstream services do the same.
      */
     SAMPLE,
 
-    /**
-     * Force the trace to not be sampled.
-     */
+    /** Do not send the trace's spans to any {@link SpanObserver} (on this service). */
     DO_NOT_SAMPLE,
 
-    /**
-     * Do not force, and let the tracer decide the observability.
-     */
+    /** Allow the {@link TraceSampler} to decide whether this trace will be observed or not. */
     UNDECIDED
 }


### PR DESCRIPTION
## Before this PR

If a service decides to start sampling a trace, it's important that all downstream service do the same to ensure we get a nice complete set of data in trace-log-viewer.

HOWEVER, if the TraceSampler decides _not_ to sample a trace, it currently imposes this DO_NOT_SAMPLE decision on all downstream services too by setting the X-B3-Sampled header to `0`

This means that theoretically if a single service early in a call graph has a low sampling rate, then it may unnecessarily reduce tracing information that all downstream services, even if they had plenty of capacity to record traces.

## After this PR

If a service decides not to observe a span, it no longer forces all the downstream services to also drop the span, and instead allows downstream samplers to decide.

Longer-term, I'd also quite like to make our trace sampling to be a target logging rate (e.g. up to 1000 lines/second) rather than just a constant percentage of incoming requests. This should mean that infrequently accessed services could just sample _every_ network request, thereby hopefully making life easier for developers.

## Possible downsides

- Rolling out this change will probably result in a higher proportion of traces getting sampled, as suddenly a request that passes through will have a chance to be sampled in every service, whereas previously the first failure would effectively blacklist that trace forever.
- I also don't really understand why you would want to mark a trace as explicitly DO_NOT_SAMPLE, so maybe I'm missing something here.

_Related to https://github.com/palantir/tracing-java/issues/32_