### PR TITLE
[improvement] Tracer spans are inexpensive for unsampled operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bin/
 .idea/
 out/
 generated_src/
+generated_testSrc/
 
 # Codegen
 .generated

--- a/tracing-benchmarks/src/jmh/java/com/palantir/tracing/TracingBenchmark.java
+++ b/tracing-benchmarks/src/jmh/java/com/palantir/tracing/TracingBenchmark.java
@@ -16,6 +16,7 @@
 
 package com.palantir.tracing;
 
+import com.google.common.util.concurrent.Runnables;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -47,7 +48,7 @@ import org.openjdk.jmh.runner.options.TimeValue;
 @SuppressWarnings({"checkstyle:hideutilityclassconstructor", "checkstyle:VisibilityModifier"})
 public class TracingBenchmark {
 
-    private static final Runnable nestedSpans = createnestedSpan(100);
+    private static final Runnable nestedSpans = createNestedSpan(100);
 
     @SuppressWarnings("ImmutableEnumChecker")
     public enum BenchmarkObservability {
@@ -87,20 +88,19 @@ public class TracingBenchmark {
         nestedSpans.run();
     }
 
-    private static Runnable createnestedSpan(int depth) {
-        if (depth == 0) {
-            return () -> {
-            };
+    private static Runnable createNestedSpan(int depth) {
+        if (depth <= 0) {
+            return Runnables.doNothing();
         } else {
-            return wrapWithSpan(createnestedSpan(depth - 1));
+            return wrapWithSpan("benchmark-span-" + depth, createNestedSpan(depth - 1));
         }
     }
 
-    private static Runnable wrapWithSpan(Runnable toBenNested) {
+    private static Runnable wrapWithSpan(String operation, Runnable next) {
         return () -> {
+            Tracer.fastStartSpan(operation);
             try {
-                Tracer.fastStartSpan("span");
-                toBenNested.run();
+                next.run();
             } finally {
                 Tracer.fastCompleteSpan();
             }

--- a/tracing-benchmarks/src/jmh/java/com/palantir/tracing/TracingBenchmark.java
+++ b/tracing-benchmarks/src/jmh/java/com/palantir/tracing/TracingBenchmark.java
@@ -99,7 +99,7 @@ public class TracingBenchmark {
     private static Runnable wrapWithSpan(Runnable toBenNested) {
         return () -> {
             try {
-                Tracer.startSpan("span");
+                Tracer.fastStartSpan("span");
                 toBenNested.run();
             } finally {
                 Tracer.fastCompleteSpan();

--- a/tracing-benchmarks/src/jmh/java/com/palantir/tracing/TracingBenchmark.java
+++ b/tracing-benchmarks/src/jmh/java/com/palantir/tracing/TracingBenchmark.java
@@ -54,7 +54,7 @@ public class TracingBenchmark {
     public enum BenchmarkObservability {
         SAMPLE(AlwaysSampler.INSTANCE),
         DO_NOT_SAMPLE(() -> false),
-        UNDECIDED(new RandomSampler(0.1f));
+        UNDECIDED(new RandomSampler(0.01f));
 
         private final TraceSampler traceSampler;
 

--- a/tracing-jaxrs/src/test/java/com/palantir/tracing/jaxrs/JaxRsTracersTest.java
+++ b/tracing-jaxrs/src/test/java/com/palantir/tracing/jaxrs/JaxRsTracersTest.java
@@ -31,9 +31,9 @@ public final class JaxRsTracersTest {
         Tracer.setSampler(AlwaysSampler.INSTANCE);
         Tracer.getAndClearTrace();
 
-        Tracer.startSpan("outside");
+        Tracer.fastStartSpan("outside");
         StreamingOutput streamingOutput = JaxRsTracers.wrap(os -> {
-            Tracer.startSpan("inside"); // never completed
+            Tracer.fastStartSpan("inside"); // never completed
         });
         streamingOutput.write(new ByteArrayOutputStream());
         assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("outside");
@@ -44,9 +44,9 @@ public final class JaxRsTracersTest {
         Tracer.setSampler(() -> false);
         Tracer.getAndClearTrace();
 
-        Tracer.startSpan("outside");
+        Tracer.fastStartSpan("outside");
         StreamingOutput streamingOutput = JaxRsTracers.wrap(os -> {
-            Tracer.startSpan("inside"); // never completed
+            Tracer.fastStartSpan("inside"); // never completed
         });
         streamingOutput.write(new ByteArrayOutputStream());
         assertThat(Tracer.hasTraceId()).isTrue();
@@ -59,11 +59,11 @@ public final class JaxRsTracersTest {
         Tracer.setSampler(AlwaysSampler.INSTANCE);
         Tracer.getAndClearTrace();
 
-        Tracer.startSpan("before-construction");
+        Tracer.fastStartSpan("before-construction");
         StreamingOutput streamingOutput = JaxRsTracers.wrap(os -> {
             assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("streaming-output");
         });
-        Tracer.startSpan("after-construction");
+        Tracer.fastStartSpan("after-construction");
         streamingOutput.write(new ByteArrayOutputStream());
     }
 
@@ -72,13 +72,13 @@ public final class JaxRsTracersTest {
         Tracer.setSampler(() -> false);
         Tracer.getAndClearTrace();
 
-        Tracer.startSpan("before-construction");
+        Tracer.fastStartSpan("before-construction");
         StreamingOutput streamingOutput = JaxRsTracers.wrap(os -> {
             assertThat(Tracer.hasTraceId()).isTrue();
             Tracer.fastCompleteSpan();
             assertThat(Tracer.hasTraceId()).isFalse();
         });
-        Tracer.startSpan("after-construction");
+        Tracer.fastStartSpan("after-construction");
         streamingOutput.write(new ByteArrayOutputStream());
     }
 }

--- a/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
+++ b/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
@@ -68,11 +68,11 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
         if (Strings.isNullOrEmpty(traceId)) {
             // HTTP request did not indicate a trace; initialize trace state and create a span.
             Tracer.initTrace(getObservabilityFromHeader(requestContext), Tracers.randomId());
-            Tracer.startSpan(operation, SpanType.SERVER_INCOMING);
+            Tracer.fastStartSpan(operation, SpanType.SERVER_INCOMING);
         } else {
             Tracer.initTrace(getObservabilityFromHeader(requestContext), traceId);
             if (spanId == null) {
-                Tracer.startSpan(operation, SpanType.SERVER_INCOMING);
+                Tracer.fastStartSpan(operation, SpanType.SERVER_INCOMING);
             } else {
                 // caller's span is this span's parent.
                 Tracer.startSpan(operation, spanId, SpanType.SERVER_INCOMING);

--- a/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
+++ b/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
@@ -75,7 +75,7 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
                 Tracer.fastStartSpan(operation, SpanType.SERVER_INCOMING);
             } else {
                 // caller's span is this span's parent.
-                Tracer.startSpan(operation, spanId, SpanType.SERVER_INCOMING);
+                Tracer.fastStartSpan(operation, spanId, SpanType.SERVER_INCOMING);
             }
         }
 

--- a/tracing-servlet/src/test/java/com/palantir/tracing/servlet/LeakedTraceFilterTest.java
+++ b/tracing-servlet/src/test/java/com/palantir/tracing/servlet/LeakedTraceFilterTest.java
@@ -103,7 +103,7 @@ public class LeakedTraceFilterTest {
                         throws IOException, ServletException {
                     // Open a span to simulate a thread from another request
                     // leaving bad data without the leaked trace filter applied.
-                    Tracer.startSpan("previous request leaked");
+                    Tracer.fastStartSpan("previous request leaked");
                     chain.doFilter(request, response);
                 }
 
@@ -140,7 +140,7 @@ public class LeakedTraceFilterTest {
             env.servlets().addServlet("alwaysLeaks", new HttpServlet() {
                 @Override
                 protected void service(HttpServletRequest req, HttpServletResponse resp) {
-                    Tracer.startSpan("leaky");
+                    Tracer.fastStartSpan("leaky");
                     resp.addHeader("Leaky-Invoked", "true");
                 }
             }).addMapping("/leaky");

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
@@ -106,7 +106,7 @@ public final class TracedOperationHandler implements HttpHandler {
             Tracer.fastStartSpan(operation, SpanType.SERVER_INCOMING);
         } else {
             // caller's span is this span's parent.
-            Tracer.startSpan(operation, spanId, SpanType.SERVER_INCOMING);
+            Tracer.fastStartSpan(operation, spanId, SpanType.SERVER_INCOMING);
         }
     }
 

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
@@ -103,7 +103,7 @@ public final class TracedOperationHandler implements HttpHandler {
         Tracer.initTrace(getObservabilityFromHeader(headers), traceId);
         String spanId = headers.getFirst(SPAN_ID); // nullable
         if (spanId == null) {
-            Tracer.startSpan(operation, SpanType.SERVER_INCOMING);
+            Tracer.fastStartSpan(operation, SpanType.SERVER_INCOMING);
         } else {
             // caller's span is this span's parent.
             Tracer.startSpan(operation, spanId, SpanType.SERVER_INCOMING);
@@ -115,7 +115,7 @@ public final class TracedOperationHandler implements HttpHandler {
         // HTTP request did not indicate a trace; initialize trace state and create a span.
         String newTraceId = Tracers.randomId();
         Tracer.initTrace(getObservabilityFromHeader(headers), newTraceId);
-        Tracer.startSpan(operation, SpanType.SERVER_INCOMING);
+        Tracer.fastStartSpan(operation, SpanType.SERVER_INCOMING);
         return newTraceId;
     }
 

--- a/tracing/src/main/java/com/palantir/tracing/AsyncTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/AsyncTracer.java
@@ -62,7 +62,7 @@ public final class AsyncTracer {
      */
     public AsyncTracer(Optional<String> operation) {
         this.operation = operation.orElse(DEFAULT_OPERATION);
-        Tracer.startSpan(this.operation + "-enqueue");
+        Tracer.fastStartSpan(this.operation + "-enqueue");
         deferredTrace = Tracer.copyTrace().get();
         Tracer.fastDiscardSpan(); // span will completed in the deferred execution
     }
@@ -76,7 +76,7 @@ public final class AsyncTracer {
         Tracer.setTrace(deferredTrace);
         // Finish the enqueue span
         Tracer.fastCompleteSpan();
-        Tracer.startSpan(operation + "-run");
+        Tracer.fastStartSpan(operation + "-run");
         try {
             return inner.call();
         } finally {

--- a/tracing/src/main/java/com/palantir/tracing/CloseableTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/CloseableTracer.java
@@ -44,7 +44,7 @@ public final class CloseableTracer implements AutoCloseable {
      * labeled with the provided operation.
      */
     public static CloseableTracer startSpan(String operation, SpanType spanType) {
-        Tracer.startSpan(operation, spanType);
+        Tracer.fastStartSpan(operation, spanType);
         return INSTANCE;
     }
 

--- a/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
@@ -108,7 +108,7 @@ public final class DeferredTracer implements Serializable {
         if (parentSpanId != null) {
             Tracer.startSpan(operation, parentSpanId, SpanType.LOCAL);
         } else {
-            Tracer.startSpan(operation);
+            Tracer.fastStartSpan(operation);
         }
 
         try {

--- a/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
@@ -106,7 +106,7 @@ public final class DeferredTracer implements Serializable {
 
         Tracer.setTrace(Trace.of(isObservable, traceId));
         if (parentSpanId != null) {
-            Tracer.startSpan(operation, parentSpanId, SpanType.LOCAL);
+            Tracer.fastStartSpan(operation, parentSpanId, SpanType.LOCAL);
         } else {
             Tracer.fastStartSpan(operation);
         }

--- a/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
@@ -104,7 +104,7 @@ public final class DeferredTracer implements Serializable {
 
         Optional<Trace> originalTrace = Tracer.copyTrace();
 
-        Tracer.setTrace(new Trace(isObservable, traceId));
+        Tracer.setTrace(Trace.of(isObservable, traceId));
         if (parentSpanId != null) {
             Tracer.startSpan(operation, parentSpanId, SpanType.LOCAL);
         } else {

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -20,6 +20,7 @@ import static com.palantir.logsafe.Preconditions.checkArgument;
 import static com.palantir.logsafe.Preconditions.checkState;
 
 import com.google.common.base.Strings;
+import com.google.errorprone.annotations.CheckReturnValue;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.tracing.api.OpenSpan;
@@ -45,7 +46,9 @@ public abstract class Trace {
     /**
      * Opens a new span for this thread's call trace, labeled with the provided operation and parent span. Only allowed
      * when the current trace is empty.
+     * If the return value is not used, prefer {@link #fastStartSpan(String, String, SpanType)}}.
      */
+    @CheckReturnValue
     final OpenSpan startSpan(String operation, String parentSpanId, SpanType type) {
         checkState(isEmpty(), "Cannot start a span with explicit parent if the current thread's trace is non-empty");
         checkArgument(!Strings.isNullOrEmpty(parentSpanId), "parentSpanId must be non-empty");
@@ -58,6 +61,7 @@ public abstract class Trace {
      * Opens a new span for this thread's call trace, labeled with the provided operation.
      * If the return value is not used, prefer {@link #fastStartSpan(String, SpanType)}}.
      */
+    @CheckReturnValue
     final OpenSpan startSpan(String operation, SpanType type) {
         Optional<OpenSpan> prevState = top();
         final OpenSpan span;
@@ -124,11 +128,13 @@ public abstract class Trace {
         }
 
         @Override
+        @SuppressWarnings("ResultOfMethodCallIgnored") // Sampled traces cannot optimize this path
         void fastStartSpan(String operation, String parentSpanId, SpanType type) {
             startSpan(operation, parentSpanId, type);
         }
 
         @Override
+        @SuppressWarnings("ResultOfMethodCallIgnored") // Sampled traces cannot optimize this path
         void fastStartSpan(String operation, SpanType type) {
             startSpan(operation, type);
         }

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -192,7 +192,7 @@ public abstract class Trace {
         private Unsampled(int numberOfSpans, String traceId) {
             super(traceId);
             this.numberOfSpans = numberOfSpans;
-            validateDepth();
+            validateNumberOfSpans();
         }
 
         private Unsampled(String traceId) {
@@ -221,7 +221,7 @@ public abstract class Trace {
 
         @Override
         Optional<OpenSpan> pop() {
-            validateDepth();
+            validateNumberOfSpans();
             if (numberOfSpans > 0) {
                 numberOfSpans--;
             }
@@ -230,7 +230,7 @@ public abstract class Trace {
 
         @Override
         boolean isEmpty() {
-            validateDepth();
+            validateNumberOfSpans();
             return numberOfSpans <= 0;
         }
 
@@ -245,7 +245,7 @@ public abstract class Trace {
         }
 
         /** Internal validation, this should never fail because {@link #pop()} only decrements positive values. */
-        private void validateDepth() {
+        private void validateNumberOfSpans() {
             if (numberOfSpans < 0) {
                 throw new SafeIllegalStateException("Unexpected negative numberOfSpans",
                         SafeArg.of("numberOfSpans", numberOfSpans));

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -240,7 +240,8 @@ public abstract class Trace {
         /** Internal validation, this should never fail because {@link #pop()} only decrements positive values. */
         private void validateDepth() {
             if (numberOfSpans < 0) {
-                throw new SafeIllegalStateException("Unexpected negative numberOfSpans", SafeArg.of("numberOfSpans", numberOfSpans));
+                throw new SafeIllegalStateException("Unexpected negative numberOfSpans",
+                        SafeArg.of("numberOfSpans", numberOfSpans));
             }
         }
 

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -93,7 +93,7 @@ public abstract class Trace {
      */
     abstract void fastStartSpan(String operation, SpanType type);
 
-    abstract void push(OpenSpan span);
+    protected abstract void push(OpenSpan span);
 
     abstract Optional<OpenSpan> top();
 
@@ -147,7 +147,7 @@ public abstract class Trace {
         }
 
         @Override
-        void push(OpenSpan span) {
+        protected void push(OpenSpan span) {
             stack.push(span);
         }
 
@@ -210,7 +210,7 @@ public abstract class Trace {
         }
 
         @Override
-        void push(OpenSpan span) {
+        protected void push(OpenSpan span) {
             numberOfSpans++;
         }
 

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -33,6 +33,13 @@ import java.util.Optional;
 /**
  * Represents a trace as an ordered list of non-completed spans. Supports adding and removing of spans. This class is
  * not thread-safe and is intended to be used in a thread-local context.
+ *
+ * There are two implementations of {@link Trace}: {@link Sampled} and {@link Unsampled}.
+ * A {@link Sampled sampled trace} records each span in order to record tracing data, however in most scenarios
+ * most traces will be {@link Unsampled}, which avoids creation of span objects, random span ID generation,
+ * clock reads, etc. Instead, the {@link Unsampled unsampled} implementation tracks the number of 'active' spans
+ * on the current thread so it can provide correct {@link Trace#isEmpty()} values allowing the {@link Tracer}
+ * utility to reset thread state after the emulated root span has been completed.
  */
 public abstract class Trace {
 

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -121,14 +121,18 @@ public final class Tracer {
 
     /**
      * Like {@link #startSpan(String)}, but opens a span of the explicitly given {@link SpanType span type}.
+     * If the return value is not used, prefer {@link Tracer#fastStartSpan(String, SpanType)}}.
      */
+    @CheckReturnValue
     public static OpenSpan startSpan(String operation, SpanType type) {
         return startSpanInternal(operation, type);
     }
 
     /**
      * Opens a new {@link SpanType#LOCAL LOCAL} span for this thread's call trace, labeled with the provided operation.
+     * If the return value is not used, prefer {@link Tracer#fastStartSpan(String)}}.
      */
+    @CheckReturnValue
     public static OpenSpan startSpan(String operation) {
         return startSpanInternal(operation, SpanType.LOCAL);
     }

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -235,7 +235,7 @@ public final class Tracers {
 
             try {
                 Tracer.initTrace(observability, Tracers.randomId());
-                Tracer.startSpan(operation);
+                Tracer.fastStartSpan(operation);
                 return delegate.call();
             } finally {
                 Tracer.fastCompleteSpan();
@@ -271,7 +271,7 @@ public final class Tracers {
 
             try {
                 Tracer.initTrace(observability, Tracers.randomId());
-                Tracer.startSpan(operation);
+                Tracer.fastStartSpan(operation);
                 delegate.run();
             } finally {
                 Tracer.fastCompleteSpan();
@@ -309,7 +309,7 @@ public final class Tracers {
 
             try {
                 Tracer.initTrace(observability, traceId);
-                Tracer.startSpan(operation);
+                Tracer.fastStartSpan(operation);
                 delegate.run();
             } finally {
                 Tracer.fastCompleteSpan();

--- a/tracing/src/test/java/com/palantir/tracing/AsyncSlf4jSpanObserverTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/AsyncSlf4jSpanObserverTest.java
@@ -101,7 +101,7 @@ public final class AsyncSlf4jSpanObserverTest {
         Tracer.subscribe(TEST_OBSERVER, AsyncSlf4jSpanObserver.of(
                 "serviceName", Inet4Address.getLoopbackAddress(), logger, executor));
         Tracer.initTrace(Observability.SAMPLE, Tracers.randomId());
-        Tracer.startSpan("operation");
+        Tracer.fastStartSpan("operation");
         Span span = Tracer.completeSpan().get();
         verify(appender, never()).doAppend(any(ILoggingEvent.class)); // async logger only fires when executor runs
 
@@ -122,7 +122,7 @@ public final class AsyncSlf4jSpanObserverTest {
         DeterministicScheduler executor = new DeterministicScheduler();
         Tracer.subscribe(TEST_OBSERVER, AsyncSlf4jSpanObserver.of("serviceName", executor));
         Tracer.initTrace(Observability.SAMPLE, Tracers.randomId());
-        Tracer.startSpan("operation");
+        Tracer.fastStartSpan("operation");
         Span span = Tracer.completeSpan().get();
 
         executor.runNextPendingCommand();
@@ -254,7 +254,7 @@ public final class AsyncSlf4jSpanObserverTest {
                 .extracting("spanId", "operation")
                 .contains(span1.getSpanId(), span1.getOperation());
 
-        Tracer.startSpan("operation");
+        Tracer.fastStartSpan("operation");
         executor.shutdown();
         Tracer.fastCompleteSpan();
     }

--- a/tracing/src/test/java/com/palantir/tracing/AsyncSlf4jSpanObserverTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/AsyncSlf4jSpanObserverTest.java
@@ -78,6 +78,8 @@ public final class AsyncSlf4jSpanObserverTest {
     public void before() {
         MockitoAnnotations.initMocks(this);
 
+        Tracer.setSampler(AlwaysSampler.INSTANCE);
+
         when(appender.getName()).thenReturn("MOCK");
         logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(AsyncSlf4jSpanObserver.class);
         logger.addAppender(appender);

--- a/tracing/src/test/java/com/palantir/tracing/AsyncTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/AsyncTracerTest.java
@@ -49,7 +49,7 @@ public class AsyncTracerTest {
     @Test
     public void completesBothDeferredSpans() {
         Tracer.initTrace(Observability.SAMPLE, "defaultTraceId");
-        Tracer.startSpan("defaultSpan");
+        Tracer.fastStartSpan("defaultSpan");
         AsyncTracer asyncTracer = new AsyncTracer();
         List<String> observedSpans = Lists.newArrayList();
         Tracer.subscribe(
@@ -64,9 +64,9 @@ public class AsyncTracerTest {
     @Test
     public void preservesState() {
         Tracer.initTrace(Observability.UNDECIDED, "defaultTraceId");
-        Tracer.startSpan("foo");
-        Tracer.startSpan("bar");
-        Tracer.startSpan("baz");
+        Tracer.fastStartSpan("foo");
+        Tracer.fastStartSpan("bar");
+        Tracer.fastStartSpan("baz");
         Trace originalTrace = getTrace();
         AsyncTracer asyncTracer = new AsyncTracer();
 

--- a/tracing/src/test/java/com/palantir/tracing/AsyncTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/AsyncTracerTest.java
@@ -20,9 +20,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Lists;
 import java.util.List;
+import org.junit.Before;
 import org.junit.Test;
 
 public class AsyncTracerTest {
+
+    @Before
+    public void before() {
+        Tracer.setSampler(AlwaysSampler.INSTANCE);
+    }
+
     @Test
     public void doesNotLeakEnqueueSpan() {
         Tracer.initTrace(Observability.UNDECIDED, "defaultTraceId");

--- a/tracing/src/test/java/com/palantir/tracing/CloseableTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/CloseableTracerTest.java
@@ -29,6 +29,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public final class CloseableTracerTest {
     @Before
     public void before() {
+        Tracer.setSampler(AlwaysSampler.INSTANCE);
         Tracer.getAndClearTrace();
     }
 

--- a/tracing/src/test/java/com/palantir/tracing/TraceTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TraceTest.java
@@ -27,13 +27,13 @@ public final class TraceTest {
 
     @Test
     public void constructTrace_emptyTraceId() {
-        assertThatThrownBy(() -> new Trace(false, ""))
+        assertThatThrownBy(() -> Trace.of(false, ""))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void testToString() {
-        Trace trace = new Trace(true, "traceId");
+        Trace trace = Trace.of(true, "traceId");
         trace.push(OpenSpan.builder()
                 .type(SpanType.LOCAL)
                 .spanId("spanId")

--- a/tracing/src/test/java/com/palantir/tracing/TraceTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TraceTest.java
@@ -34,14 +34,10 @@ public final class TraceTest {
     @Test
     public void testToString() {
         Trace trace = Trace.of(true, "traceId");
-        trace.push(OpenSpan.builder()
-                .type(SpanType.LOCAL)
-                .spanId("spanId")
-                .operation("operation")
-                .startClockNanoSeconds(0L)
-                .startTimeMicroSeconds(0L)
-                .build());
-        assertThat(trace.toString()).isEqualTo("Trace{stack=[OpenSpan{operation=operation, startTimeMicroSeconds=0, "
-                + "startClockNanoSeconds=0, spanId=spanId, type=LOCAL}], isObservable=true, traceId='traceId'}");
+        OpenSpan span = trace.startSpan("operation", SpanType.LOCAL);
+        assertThat(trace.toString())
+                .isEqualTo("Trace{stack=[" + span + "], isObservable=true, traceId='traceId'}")
+                .contains(span.getOperation())
+                .contains(span.getSpanId());
     }
 }

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -152,8 +152,8 @@ public final class TracerTest {
         assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(traceId);
         assertThat(Tracer.hasTraceId()).isTrue();
         assertThat(Tracer.getTraceId()).isEqualTo(traceId);
-        Tracer.startSpan("foo");
-        Tracer.startSpan("bar");
+        Tracer.fastStartSpan("foo");
+        Tracer.fastStartSpan("bar");
 
         Tracer.fastCompleteSpan();
         // Unsampled trace should still apply thread state
@@ -186,7 +186,7 @@ public final class TracerTest {
 
     @Test
     public void testTraceCopyIsIndependent() throws Exception {
-        Tracer.startSpan("span");
+        Tracer.fastStartSpan("span");
         try {
             Trace trace = Tracer.copyTrace().get();
             trace.push(mock(OpenSpan.class));
@@ -198,7 +198,7 @@ public final class TracerTest {
 
     @Test
     public void testSetTraceSetsCurrentTraceAndMdcTraceIdKey() throws Exception {
-        Tracer.startSpan("operation");
+        Tracer.fastStartSpan("operation");
         Tracer.setTrace(Trace.of(true, "newTraceId"));
         assertThat(Tracer.getTraceId()).isEqualTo("newTraceId");
         assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo("newTraceId");
@@ -225,12 +225,12 @@ public final class TracerTest {
     @Test
     public void testCompletedSpanHasCorrectSpanType() throws Exception {
         for (SpanType type : SpanType.values()) {
-            Tracer.startSpan("1", type);
+            Tracer.fastStartSpan("1", type);
             assertThat(Tracer.completeSpan().get().type()).isEqualTo(type);
         }
 
         // Default is LOCAL
-        Tracer.startSpan("1");
+        Tracer.fastStartSpan("1");
         assertThat(Tracer.completeSpan().get().type()).isEqualTo(SpanType.LOCAL);
     }
 
@@ -239,7 +239,7 @@ public final class TracerTest {
         Map<String, String> metadata = ImmutableMap.of(
                 "key1", "value1",
                 "key2", "value2");
-        Tracer.startSpan("operation");
+        Tracer.fastStartSpan("operation");
         Optional<Span> maybeSpan = Tracer.completeSpan(metadata);
         assertTrue(maybeSpan.isPresent());
         assertThat(maybeSpan.get().getMetadata()).isEqualTo(metadata);
@@ -254,7 +254,7 @@ public final class TracerTest {
     public void testFastCompleteSpan() {
         Tracer.subscribe("1", observer1);
         String operation = "operation";
-        Tracer.startSpan(operation);
+        Tracer.fastStartSpan(operation);
         Tracer.fastCompleteSpan();
         verify(observer1).consume(spanCaptor.capture());
         assertThat(spanCaptor.getValue().getOperation()).isEqualTo(operation);
@@ -265,7 +265,7 @@ public final class TracerTest {
         Tracer.subscribe("1", observer1);
         Map<String, String> metadata = ImmutableMap.of("key", "value");
         String operation = "operation";
-        Tracer.startSpan("operation");
+        Tracer.fastStartSpan("operation");
         Tracer.fastCompleteSpan(metadata);
         verify(observer1).consume(spanCaptor.capture());
         assertThat(spanCaptor.getValue().getOperation()).isEqualTo(operation);
@@ -282,7 +282,7 @@ public final class TracerTest {
             throw new IllegalStateException("2");
         });
         String operation = "operation";
-        Tracer.startSpan(operation);
+        Tracer.fastStartSpan(operation);
         Tracer.fastCompleteSpan();
         verify(observer1).consume(spanCaptor.capture());
         assertThat(spanCaptor.getValue().getOperation()).isEqualTo(operation);
@@ -304,7 +304,7 @@ public final class TracerTest {
 
     @Test
     public void testClearAndGetTraceClearsMdc() {
-        Tracer.startSpan("test");
+        Tracer.fastStartSpan("test");
         try {
             String startTrace = Tracer.getTraceId();
             assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(startTrace);
@@ -336,7 +336,7 @@ public final class TracerTest {
     @Test
     public void testHasTraceId() {
         assertThat(Tracer.hasTraceId()).isEqualTo(false);
-        Tracer.startSpan("testSpan");
+        Tracer.fastStartSpan("testSpan");
         try {
             assertThat(Tracer.hasTraceId()).isEqualTo(true);
         } finally {
@@ -346,12 +346,12 @@ public final class TracerTest {
     }
 
     private static void startAndFastCompleteSpan() {
-        Tracer.startSpan("operation");
+        Tracer.fastStartSpan("operation");
         Tracer.fastCompleteSpan();
     }
 
     private static Span startAndCompleteSpan() {
-        Tracer.startSpan("operation");
+        Tracer.fastStartSpan("operation");
         return Tracer.completeSpan().get();
     }
 }

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -19,13 +19,11 @@ package com.palantir.tracing;
 import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
-import com.palantir.tracing.api.OpenSpan;
 import com.palantir.tracing.api.Span;
 import com.palantir.tracing.api.SpanObserver;
 import com.palantir.tracing.api.SpanType;
@@ -198,7 +196,7 @@ public final class TracerTest {
         Tracer.fastStartSpan("span");
         try {
             Trace trace = Tracer.copyTrace().get();
-            trace.push(mock(OpenSpan.class));
+            trace.fastStartSpan("fop", SpanType.LOCAL);
         } finally {
             Tracer.fastCompleteSpan();
         }

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -70,6 +70,7 @@ public final class TracerTest {
     }
 
     @Test
+    @SuppressWarnings("ResultOfMethodCallIgnored") // testing that exceptions are thrown
     public void testIdsMustBeNonNullAndNotEmpty() throws Exception {
         assertThatLoggableExceptionThrownBy(() -> Tracer.initTrace(Observability.UNDECIDED, null))
                 .hasLogMessage("traceId must be non-empty")
@@ -84,6 +85,14 @@ public final class TracerTest {
                 .hasArgs();
 
         assertThatLoggableExceptionThrownBy(() -> Tracer.startSpan("op", "", null))
+                .hasLogMessage("parentSpanId must be non-empty")
+                .hasArgs();
+
+        assertThatLoggableExceptionThrownBy(() -> Tracer.fastStartSpan("op", null, null))
+                .hasLogMessage("parentSpanId must be non-empty")
+                .hasArgs();
+
+        assertThatLoggableExceptionThrownBy(() -> Tracer.fastStartSpan("op", "", null))
                 .hasLogMessage("parentSpanId must be non-empty")
                 .hasArgs();
     }

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -45,6 +45,7 @@ public final class TracersTest {
         MockitoAnnotations.initMocks(this);
         MDC.clear();
 
+        Tracer.setSampler(AlwaysSampler.INSTANCE);
         // Initialize a new trace for each test
         Tracer.initTrace(Observability.UNDECIDED, "defaultTraceId");
     }

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -66,9 +66,9 @@ public final class TracersTest {
         wrappedService.submit(traceExpectingCallableWithSingleSpan("DeferredTracer(unnamed operation)")).get();
 
         // Non-empty trace
-        Tracer.startSpan("foo");
-        Tracer.startSpan("bar");
-        Tracer.startSpan("baz");
+        Tracer.fastStartSpan("foo");
+        Tracer.fastStartSpan("bar");
+        Tracer.fastStartSpan("baz");
         wrappedService.submit(traceExpectingCallableWithSingleSpan("DeferredTracer(unnamed operation)")).get();
         wrappedService.submit(traceExpectingCallableWithSingleSpan("DeferredTracer(unnamed operation)")).get();
         Tracer.fastCompleteSpan();
@@ -86,9 +86,9 @@ public final class TracersTest {
         wrappedService.submit(traceExpectingRunnableWithSingleSpan("operation")).get();
 
         // Non-empty trace
-        Tracer.startSpan("foo");
-        Tracer.startSpan("bar");
-        Tracer.startSpan("baz");
+        Tracer.fastStartSpan("foo");
+        Tracer.fastStartSpan("bar");
+        Tracer.fastStartSpan("baz");
         wrappedService.submit(traceExpectingCallableWithSingleSpan("operation")).get();
         wrappedService.submit(traceExpectingRunnableWithSingleSpan("operation")).get();
         Tracer.fastCompleteSpan();
@@ -108,9 +108,9 @@ public final class TracersTest {
                 traceExpectingRunnableWithSingleSpan("DeferredTracer(unnamed operation)"), 0, TimeUnit.SECONDS).get();
 
         // Non-empty trace
-        Tracer.startSpan("foo");
-        Tracer.startSpan("bar");
-        Tracer.startSpan("baz");
+        Tracer.fastStartSpan("foo");
+        Tracer.fastStartSpan("bar");
+        Tracer.fastStartSpan("baz");
         wrappedService.schedule(
                 traceExpectingCallableWithSingleSpan("DeferredTracer(unnamed operation)"), 0, TimeUnit.SECONDS).get();
         wrappedService.schedule(
@@ -130,9 +130,9 @@ public final class TracersTest {
         wrappedService.schedule(traceExpectingRunnableWithSingleSpan("operation"), 0, TimeUnit.SECONDS).get();
 
         // Non-empty trace
-        Tracer.startSpan("foo");
-        Tracer.startSpan("bar");
-        Tracer.startSpan("baz");
+        Tracer.fastStartSpan("foo");
+        Tracer.fastStartSpan("bar");
+        Tracer.fastStartSpan("baz");
         wrappedService.schedule(traceExpectingCallableWithSingleSpan("operation"), 0, TimeUnit.SECONDS).get();
         wrappedService.schedule(traceExpectingRunnableWithSingleSpan("operation"), 0, TimeUnit.SECONDS).get();
         Tracer.fastCompleteSpan();
@@ -156,9 +156,9 @@ public final class TracersTest {
         wrappedService.submit(runnable).get();
 
         // Non-empty trace
-        Tracer.startSpan("foo");
-        Tracer.startSpan("bar");
-        Tracer.startSpan("baz");
+        Tracer.fastStartSpan("foo");
+        Tracer.fastStartSpan("bar");
+        Tracer.fastStartSpan("baz");
         wrappedService.submit(callable).get();
         wrappedService.submit(runnable).get();
         Tracer.fastCompleteSpan();
@@ -182,9 +182,9 @@ public final class TracersTest {
         wrappedService.schedule(runnable, 0, TimeUnit.SECONDS).get();
 
         // Non-empty trace
-        Tracer.startSpan("foo");
-        Tracer.startSpan("bar");
-        Tracer.startSpan("baz");
+        Tracer.fastStartSpan("foo");
+        Tracer.fastStartSpan("bar");
+        Tracer.fastStartSpan("baz");
         wrappedService.schedule(callable, 0, TimeUnit.SECONDS).get();
         wrappedService.schedule(runnable, 0, TimeUnit.SECONDS).get();
         Tracer.fastCompleteSpan();
@@ -194,9 +194,9 @@ public final class TracersTest {
 
     @Test
     public void testWrapCallable_callableTraceIsIsolated() throws Exception {
-        Tracer.startSpan("outside");
+        Tracer.fastStartSpan("outside");
         Callable<Void> callable = Tracers.wrap(() -> {
-            Tracer.startSpan("inside"); // never completed
+            Tracer.fastStartSpan("inside"); // never completed
             return null;
         });
         callable.call();
@@ -205,18 +205,18 @@ public final class TracersTest {
 
     @Test
     public void testWrapCallable_traceStateIsCapturedAtConstructionTime() throws Exception {
-        Tracer.startSpan("before-construction");
+        Tracer.fastStartSpan("before-construction");
         Callable<Void> callable = Tracers.wrap(() -> {
             assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("DeferredTracer(unnamed operation)");
             return null;
         });
-        Tracer.startSpan("after-construction");
+        Tracer.fastStartSpan("after-construction");
         callable.call();
     }
 
     @Test
     public void testWrapCallable_withSpan() throws Exception {
-        Tracer.startSpan("outside");
+        Tracer.fastStartSpan("outside");
         Runnable runnable = Tracers.wrap("operation", () -> {
             assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("operation");
         });
@@ -226,9 +226,9 @@ public final class TracersTest {
 
     @Test
     public void testWrapRunnable_runnableTraceIsIsolated() throws Exception {
-        Tracer.startSpan("outside");
+        Tracer.fastStartSpan("outside");
         Runnable runnable = Tracers.wrap(() -> {
-            Tracer.startSpan("inside"); // never completed
+            Tracer.fastStartSpan("inside"); // never completed
         });
         runnable.run();
         assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("outside");
@@ -236,17 +236,17 @@ public final class TracersTest {
 
     @Test
     public void testWrapRunnable_traceStateIsCapturedAtConstructionTime() throws Exception {
-        Tracer.startSpan("before-construction");
+        Tracer.fastStartSpan("before-construction");
         Runnable runnable = Tracers.wrap(() -> {
             assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("DeferredTracer(unnamed operation)");
         });
-        Tracer.startSpan("after-construction");
+        Tracer.fastStartSpan("after-construction");
         runnable.run();
     }
 
     @Test
     public void testWrapRunnable_startsNewSpan() throws Exception {
-        Tracer.startSpan("outside");
+        Tracer.fastStartSpan("outside");
         Runnable runnable = Tracers.wrap("operation", () -> {
             assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("operation");
         });


### PR DESCRIPTION
## Before this PR
Operations which are fast in the common case were infeasible to trace because regardless of the trace rate, span creation performance was worse than the operation being measured.

```
Benchmark                                                      (observability)  Mode  Cnt      Score       Error   Units
TracingBenchmark.nestedSpans                                            SAMPLE  avgt    3  39710.354 ± 36443.873   ns/op
TracingBenchmark.nestedSpans:·gc.alloc.rate                             SAMPLE  avgt    3   3425.430 ±  3215.533  MB/sec
TracingBenchmark.nestedSpans:·gc.alloc.rate.norm                        SAMPLE  avgt    3  41560.021 ±     0.434    B/op
TracingBenchmark.nestedSpans:·gc.churn.PS_Eden_Space                    SAMPLE  avgt    3   3444.571 ±  3116.221  MB/sec
TracingBenchmark.nestedSpans:·gc.churn.PS_Eden_Space.norm               SAMPLE  avgt    3  41795.982 ±  7880.516    B/op
TracingBenchmark.nestedSpans:·gc.churn.PS_Survivor_Space                SAMPLE  avgt    3      0.386 ±     2.219  MB/sec
TracingBenchmark.nestedSpans:·gc.churn.PS_Survivor_Space.norm           SAMPLE  avgt    3      4.741 ±    30.088    B/op
TracingBenchmark.nestedSpans:·gc.count                                  SAMPLE  avgt    3    137.000              counts
TracingBenchmark.nestedSpans:·gc.time                                   SAMPLE  avgt    3     87.000                  ms
TracingBenchmark.nestedSpans                                     DO_NOT_SAMPLE  avgt    3  19958.082 ±  6584.116   ns/op
TracingBenchmark.nestedSpans:·gc.alloc.rate                      DO_NOT_SAMPLE  avgt    3   3506.264 ±  1147.188  MB/sec
TracingBenchmark.nestedSpans:·gc.alloc.rate.norm                 DO_NOT_SAMPLE  avgt    3  21416.011 ±     0.230    B/op
TracingBenchmark.nestedSpans:·gc.churn.PS_Eden_Space             DO_NOT_SAMPLE  avgt    3   3547.447 ±  1525.303  MB/sec
TracingBenchmark.nestedSpans:·gc.churn.PS_Eden_Space.norm        DO_NOT_SAMPLE  avgt    3  21666.731 ±  4251.611    B/op
TracingBenchmark.nestedSpans:·gc.churn.PS_Survivor_Space         DO_NOT_SAMPLE  avgt    3      0.383 ±     0.331  MB/sec
TracingBenchmark.nestedSpans:·gc.churn.PS_Survivor_Space.norm    DO_NOT_SAMPLE  avgt    3      2.341 ±     1.300    B/op
TracingBenchmark.nestedSpans:·gc.count                           DO_NOT_SAMPLE  avgt    3    139.000              counts
TracingBenchmark.nestedSpans:·gc.time                            DO_NOT_SAMPLE  avgt    3     86.000                  ms
TracingBenchmark.nestedSpans                                         UNDECIDED  avgt    3  22570.008 ±  7874.344   ns/op
TracingBenchmark.nestedSpans:·gc.alloc.rate                          UNDECIDED  avgt    3   3590.635 ±  1268.870  MB/sec
TracingBenchmark.nestedSpans:·gc.alloc.rate.norm                     UNDECIDED  avgt    3  24792.658 ±    44.976    B/op
TracingBenchmark.nestedSpans:·gc.churn.PS_Eden_Space                 UNDECIDED  avgt    3   3674.586 ±  3668.504  MB/sec
TracingBenchmark.nestedSpans:·gc.churn.PS_Eden_Space.norm            UNDECIDED  avgt    3  25360.986 ± 16430.980    B/op
TracingBenchmark.nestedSpans:·gc.churn.PS_Survivor_Space             UNDECIDED  avgt    3      0.217 ±     2.148  MB/sec
TracingBenchmark.nestedSpans:·gc.churn.PS_Survivor_Space.norm        UNDECIDED  avgt    3      1.509 ±    15.297    B/op
TracingBenchmark.nestedSpans:·gc.count                               UNDECIDED  avgt    3     90.000              counts
TracingBenchmark.nestedSpans:·gc.time                                UNDECIDED  avgt    3     58.000                  ms
```

## After this PR
Added `Tracer.fastStartSpan` which can effectively no-op for unsampled operations.

```
Benchmark                                                      (observability)  Mode  Cnt      Score       Error   Units
TracingBenchmark.nestedSpans                                            SAMPLE  avgt    3  37969.436 ± 25282.797   ns/op
TracingBenchmark.nestedSpans:·gc.alloc.rate                             SAMPLE  avgt    3   3475.679 ±  2277.025  MB/sec
TracingBenchmark.nestedSpans:·gc.alloc.rate.norm                        SAMPLE  avgt    3  40360.062 ±     1.751    B/op
TracingBenchmark.nestedSpans:·gc.churn.PS_Eden_Space                    SAMPLE  avgt    3   3511.677 ±  2743.986  MB/sec
TracingBenchmark.nestedSpans:·gc.churn.PS_Eden_Space.norm               SAMPLE  avgt    3  40771.767 ±  7164.960    B/op
TracingBenchmark.nestedSpans:·gc.churn.PS_Survivor_Space                SAMPLE  avgt    3      0.384 ±     0.428  MB/sec
TracingBenchmark.nestedSpans:·gc.churn.PS_Survivor_Space.norm           SAMPLE  avgt    3      4.451 ±     2.688    B/op
TracingBenchmark.nestedSpans:·gc.count                                  SAMPLE  avgt    3    148.000              counts
TracingBenchmark.nestedSpans:·gc.time                                   SAMPLE  avgt    3     88.000                  ms
TracingBenchmark.nestedSpans                                     DO_NOT_SAMPLE  avgt    3    908.402 ±    79.755   ns/op
TracingBenchmark.nestedSpans:·gc.alloc.rate                      DO_NOT_SAMPLE  avgt    3   2820.275 ±   290.026  MB/sec
TracingBenchmark.nestedSpans:·gc.alloc.rate.norm                 DO_NOT_SAMPLE  avgt    3    784.001 ±     0.011    B/op
TracingBenchmark.nestedSpans:·gc.churn.PS_Eden_Space             DO_NOT_SAMPLE  avgt    3   2834.984 ±   293.831  MB/sec
TracingBenchmark.nestedSpans:·gc.churn.PS_Eden_Space.norm        DO_NOT_SAMPLE  avgt    3    788.123 ±   162.926    B/op
TracingBenchmark.nestedSpans:·gc.churn.PS_Survivor_Space         DO_NOT_SAMPLE  avgt    3      0.223 ±     1.492  MB/sec
TracingBenchmark.nestedSpans:·gc.churn.PS_Survivor_Space.norm    DO_NOT_SAMPLE  avgt    3      0.062 ±     0.416    B/op
TracingBenchmark.nestedSpans:·gc.count                           DO_NOT_SAMPLE  avgt    3    126.000              counts
TracingBenchmark.nestedSpans:·gc.time                            DO_NOT_SAMPLE  avgt    3     77.000                  ms
TracingBenchmark.nestedSpans                                         UNDECIDED  avgt    3   1254.746 ±   233.856   ns/op
TracingBenchmark.nestedSpans:·gc.alloc.rate                          UNDECIDED  avgt    3   2945.625 ±   514.073  MB/sec
TracingBenchmark.nestedSpans:·gc.alloc.rate.norm                     UNDECIDED  avgt    3   1130.854 ±    22.743    B/op
TracingBenchmark.nestedSpans:·gc.churn.PS_Eden_Space                 UNDECIDED  avgt    3   2993.199 ±  1125.922  MB/sec
TracingBenchmark.nestedSpans:·gc.churn.PS_Eden_Space.norm            UNDECIDED  avgt    3   1149.047 ±   258.339    B/op
TracingBenchmark.nestedSpans:·gc.churn.PS_Survivor_Space             UNDECIDED  avgt    3      0.279 ±     0.890  MB/sec
TracingBenchmark.nestedSpans:·gc.churn.PS_Survivor_Space.norm        UNDECIDED  avgt    3      0.107 ±     0.355    B/op
TracingBenchmark.nestedSpans:·gc.count                               UNDECIDED  avgt    3    135.000              counts
TracingBenchmark.nestedSpans:·gc.time                                UNDECIDED  avgt    3     81.000                  ms
```