### PR TITLE
Add initTrace javadoc regarding trace lifetime

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -100,6 +100,9 @@ public final class Tracer {
 
     /**
      * Initializes the current thread's trace, erasing any previously accrued open spans.
+     *
+     * The new trace will be persistent for the duration of the next span opened on it via
+     * {@link #startSpan}, and will be discarded when that span is completed or discarded.
      */
     public static void initTrace(Observability observability, String traceId) {
         setTrace(createTrace(observability, traceId));


### PR DESCRIPTION
## Before this PR
It is very unclear that a traceid registered with `.initTrace` will be cleared as soon as the first span is closed.

## After this PR
Javadoc includes information about trace lifetime

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

