### PR TITLE
Remove jackson from api

### DIFF
--- a/changelog/@unreleased/remove-jackson-api-dep.v2.yml
+++ b/changelog/@unreleased/remove-jackson-api-dep.v2.yml
@@ -1,0 +1,5 @@
+type: break
+break:
+  description: Removed jackson-databind and jackson-annotations from tracing-api.
+  links:
+    - https://github.com/palantir/tracing-java/pull/209

--- a/tracing-api/build.gradle
+++ b/tracing-api/build.gradle
@@ -1,9 +1,6 @@
 apply from: "$rootDir/gradle/publish-jar.gradle"
 
 dependencies {
-    compile "com.fasterxml.jackson.core:jackson-databind"
-    implementation 'com.fasterxml.jackson.core:jackson-annotations'
-
     testCompile "junit:junit"
     testCompile "org.assertj:assertj-core"
     testCompile "org.mockito:mockito-core"

--- a/tracing-api/src/main/java/com/palantir/tracing/api/Span.java
+++ b/tracing-api/src/main/java/com/palantir/tracing/api/Span.java
@@ -16,8 +16,6 @@
 
 package com.palantir.tracing.api;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
 import java.util.Optional;
 import org.immutables.value.Value;
@@ -25,8 +23,6 @@ import org.immutables.value.Value;
 /**
  * A value class representing a completed Span, see {@link OpenSpan} for a description of the fields.
  */
-@JsonDeserialize(as = ImmutableSpan.class)
-@JsonSerialize(as = ImmutableSpan.class)
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
 public abstract class Span {


### PR DESCRIPTION


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
Reduces the dependency footprint of the tracing api by removing
Jackson. This dep is used on one class to add JsonDeserialization,
but is unused.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Anyone that attempts to deserialize Spans would no longer be able to do so.
