### PR TITLE
Fix #177: Add APIs for Supplier<String> operation names

### DIFF
--- a/changelog/@unreleased/pr-262.v2.yml
+++ b/changelog/@unreleased/pr-262.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add Supplier<String> operation name APIs for lazy operation name evaluation
+  links:
+  - https://github.com/palantir/tracing-java/pull/262

--- a/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
+++ b/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
@@ -25,6 +25,7 @@ import com.palantir.tracing.api.SpanType;
 import com.palantir.tracing.api.TraceHttpHeaders;
 import java.io.IOException;
 import java.util.Optional;
+import java.util.function.Supplier;
 import javax.annotation.Priority;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -55,12 +56,10 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
     // Handles incoming request
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
-        String path = Optional.ofNullable(uriInfo)
+        Supplier<String> operation = () -> "Jersey: " + requestContext.getMethod() + " " + Optional.ofNullable(uriInfo)
                 .map(ExtendedUriInfo::getMatchedModelResource)
                 .map(Resource::getPath)
                 .orElse("(unknown)");
-
-        String operation = "Jersey: " + requestContext.getMethod() + " " + path;
         // The following strings are all nullable
         String traceId = requestContext.getHeaderString(TraceHttpHeaders.TRACE_ID);
         String spanId = requestContext.getHeaderString(TraceHttpHeaders.SPAN_ID);

--- a/tracing/src/main/java/com/palantir/tracing/CloseableTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/CloseableTracer.java
@@ -17,6 +17,7 @@
 package com.palantir.tracing;
 
 import com.palantir.tracing.api.SpanType;
+import java.util.function.Supplier;
 
 /**
  * Wraps the {@link Tracer} methods in a closeable resource to enable the usage of the try-with-resources pattern.
@@ -40,12 +41,30 @@ public final class CloseableTracer implements AutoCloseable {
     }
 
     /**
+     * Opens a new {@link SpanType#LOCAL LOCAL} span for this thread's call trace, labeled with the provided operation.
+     */
+    public static CloseableTracer startSpan(Supplier<String> operation) {
+        return startSpan(operation, SpanType.LOCAL);
+    }
+
+    /**
      * Opens a new span for this thread's call trace with the provided {@link SpanType},
      * labeled with the provided operation.
      *
      * If you need to a span that may complete on another thread, use {@link DetachedSpan#start} instead.
      */
     public static CloseableTracer startSpan(String operation, SpanType spanType) {
+        Tracer.fastStartSpan(operation, spanType);
+        return INSTANCE;
+    }
+
+    /**
+     * Opens a new span for this thread's call trace with the provided {@link SpanType},
+     * labeled with the provided operation.
+     *
+     * If you need to a span that may complete on another thread, use {@link DetachedSpan#start} instead.
+     */
+    public static CloseableTracer startSpan(Supplier<String> operation, SpanType spanType) {
         Tracer.fastStartSpan(operation, spanType);
         return INSTANCE;
     }

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -29,6 +29,7 @@ import com.palantir.tracing.api.SpanType;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * Represents a trace as an ordered list of non-completed spans. Supports adding and removing of spans. This class is
@@ -115,6 +116,16 @@ public abstract class Trace {
      */
     abstract void fastStartSpan(String operation, SpanType type);
 
+    /**
+     * Like {@link #startSpan(String, String, SpanType)}, but does not return an {@link OpenSpan}.
+     */
+    abstract void fastStartSpan(Supplier<String> operation, String parentSpanId, SpanType type);
+
+    /**
+     * Like {@link #startSpan(String, SpanType)}, but does not return an {@link OpenSpan}.
+     */
+    abstract void fastStartSpan(Supplier<String> operation, SpanType type);
+
     protected abstract void push(OpenSpan span);
 
     abstract Optional<OpenSpan> top();
@@ -168,6 +179,16 @@ public abstract class Trace {
         @SuppressWarnings("ResultOfMethodCallIgnored") // Sampled traces cannot optimize this path
         void fastStartSpan(String operation, SpanType type) {
             startSpan(operation, type);
+        }
+
+        @Override
+        void fastStartSpan(Supplier<String> operation, String parentSpanId, SpanType type) {
+            fastStartSpan(operation.get(), parentSpanId, type);
+        }
+
+        @Override
+        void fastStartSpan(Supplier<String> operation, SpanType type) {
+            fastStartSpan(operation.get(), type);
         }
 
         @Override
@@ -239,6 +260,16 @@ public abstract class Trace {
 
         @Override
         void fastStartSpan(String operation, SpanType type) {
+            numberOfSpans++;
+        }
+
+        @Override
+        void fastStartSpan(Supplier<String> operation, String parentSpanId, SpanType type) {
+            numberOfSpans++;
+        }
+
+        @Override
+        void fastStartSpan(Supplier<String> operation, SpanType type) {
             numberOfSpans++;
         }
 

--- a/tracing/src/test/java/com/palantir/tracing/CloseableTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/CloseableTracerTest.java
@@ -45,8 +45,28 @@ public final class CloseableTracerTest {
     }
 
     @Test
+    public void startsAndClosesSpan_supplier() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan(() -> "foo")) {
+            OpenSpan openSpan = Tracer.copyTrace().get().top().get();
+            assertThat(openSpan.getOperation()).isEqualTo("foo");
+            assertThat(openSpan.type()).isEqualTo(SpanType.LOCAL);
+        }
+        assertThat(Tracer.getAndClearTrace().top()).isEmpty();
+    }
+
+    @Test
     public void startsAndClosesSpanWithType() {
         try (CloseableTracer tracer = CloseableTracer.startSpan("foo", SpanType.CLIENT_OUTGOING)) {
+            OpenSpan openSpan = Tracer.copyTrace().get().top().get();
+            assertThat(openSpan.getOperation()).isEqualTo("foo");
+            assertThat(openSpan.type()).isEqualTo(SpanType.CLIENT_OUTGOING);
+        }
+        assertThat(Tracer.getAndClearTrace().top()).isEmpty();
+    }
+
+    @Test
+    public void startsAndClosesSpanWithType_supplier() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan(() -> "foo", SpanType.CLIENT_OUTGOING)) {
             OpenSpan openSpan = Tracer.copyTrace().get().top().get();
             assertThat(openSpan.getOperation()).isEqualTo("foo");
             assertThat(openSpan.type()).isEqualTo(SpanType.CLIENT_OUTGOING);

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -271,6 +271,16 @@ public final class TracerTest {
     }
 
     @Test
+    public void testFastCompleteSpan_supplier() {
+        Tracer.subscribe("1", observer1);
+        String operation = "operation";
+        Tracer.fastStartSpan(() -> operation);
+        Tracer.fastCompleteSpan();
+        verify(observer1).consume(spanCaptor.capture());
+        assertThat(spanCaptor.getValue().getOperation()).isEqualTo(operation);
+    }
+
+    @Test
     public void testFastCompleteSpanWithMetadata() {
         Tracer.subscribe("1", observer1);
         Map<String, String> metadata = ImmutableMap.of("key", "value");


### PR DESCRIPTION
## Before this PR
Hacks scattered across consumers to avoid expensive string work when the name will not be used, e.g. https://github.com/palantir/tritium/blob/880c6da14f7d89644fce935a5fe0fb8e080b4586/tritium-tracing/src/main/java/com/palantir/tritium/tracing/TracingInvocationEventHandler.java#L97-L103

## After this PR
`CloseableTracer.startSpan(() -> "Foo: " + bar)`
`Tracer.fastStartSpan(() -> "Foo: " + bar)`
==COMMIT_MSG==
Add Supplier<String> operation name APIs for lazy operation name evaluation
==COMMIT_MSG==

