### PR TITLE
Tracing aware executors wrap Runnables and Callables more cleanly

### DIFF
--- a/changelog/@unreleased/pr-310.v2.yml
+++ b/changelog/@unreleased/pr-310.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Tracing aware executors wrap Runnables and Callables more cleanly
+  links:
+  - https://github.com/palantir/tracing-java/pull/310

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -77,6 +77,11 @@ public final class Tracers {
             protected <T> Callable<T> wrapTask(Callable<T> callable) {
                 return wrap(callable);
             }
+
+            @Override
+            protected Runnable wrapTask(Runnable command) {
+                return wrap(command);
+            }
         };
     }
 
@@ -89,6 +94,11 @@ public final class Tracers {
             @Override
             protected <T> Callable<T> wrapTask(Callable<T> callable) {
                 return wrap(operation, callable);
+            }
+
+            @Override
+            protected Runnable wrapTask(Runnable command) {
+                return wrap(operation, command);
             }
         };
     }
@@ -105,6 +115,11 @@ public final class Tracers {
             protected <T> Callable<T> wrapTask(Callable<T> callable) {
                 return wrap(callable);
             }
+
+            @Override
+            protected Runnable wrapTask(Runnable command) {
+                return wrap(command);
+            }
         };
     }
 
@@ -118,6 +133,11 @@ public final class Tracers {
             @Override
             protected <T> Callable<T> wrapTask(Callable<T> callable) {
                 return wrap(operation, callable);
+            }
+
+            @Override
+            protected Runnable wrapTask(Runnable command) {
+                return wrap(operation, command);
             }
         };
     }
@@ -177,6 +197,11 @@ public final class Tracers {
             protected <T> Callable<T> wrapTask(Callable<T> callable) {
                 return wrapWithNewTrace(operation, callable);
             }
+
+            @Override
+            protected Runnable wrapTask(Runnable command) {
+                return wrapWithNewTrace(operation, command);
+            }
         };
     }
 
@@ -203,6 +228,11 @@ public final class Tracers {
             @Override
             protected <T> Callable<T> wrapTask(Callable<T> callable) {
                 return wrapWithNewTrace(operation, callable);
+            }
+
+            @Override
+            protected Runnable wrapTask(Runnable command) {
+                return wrapWithNewTrace(operation, command);
             }
         };
     }
@@ -353,7 +383,9 @@ public final class Tracers {
 
         @Override
         public V call() throws Exception {
-            return this.deferredTracer.withTrace(delegate::call);
+            try (DeferredTracer.CloseableTrace ignored = deferredTracer.withTrace()) {
+                return delegate.call();
+            }
         }
     }
 
@@ -373,10 +405,9 @@ public final class Tracers {
 
         @Override
         public void run() {
-            deferredTracer.withTrace(() -> {
+            try (DeferredTracer.CloseableTrace ignored = deferredTracer.withTrace()) {
                 delegate.run();
-                return true;
-            });
+            }
         }
     }
 


### PR DESCRIPTION
==COMMIT_MSG==
Firstly, we should not optimize around stack depth in most cases
because it can result in large methods that the JVM cannot efficiently
inline and additional GC pressure depending on the implementation.

However, we use tracing a lot, a tracing wrapped executor shows up
in ~50% of stack traces in a large internal service, and exceptions
propagate through multiple executors in many cases.
This would not make sense to change if the tracing stack frames
provided information, but wrapping from runnable to callable
isn't helpful, nor are lambda frames to turn a Callable into
a ThrowingCallable.

This change is completely internal to tracing and does not expose
any new public APIs.

Before: frames 2, 3, 4, and 5 are from tracing
```
com.palantir.logsafe.exceptions.SafeRuntimeException: Stack Trace
        at com.palantir.tracing.TracerTest.lambda$testStackDepth$9(TracerTest.java:486)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at com.palantir.tracing.DeferredTracer.withTrace(DeferredTracer.java:104)
        at com.palantir.tracing.Tracers$TracingAwareCallable.call(Tracers.java:356)
        at com.palantir.tracing.WrappingExecutorService.lambda$wrapTask$0(WrappingExecutorService.java:67)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

After: line 2 handles tracing, the rest would be present without tracing
```
com.palantir.logsafe.exceptions.SafeRuntimeException: Stack Trace
        at com.palantir.tracing.TracerTest.lambda$testStackDepth$9(TracerTest.java:486)
        at com.palantir.tracing.Tracers$TracingAwareRunnable.run(Tracers.java:409)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```
==COMMIT_MSG==

## Possible downsides?
none.

