### PR TITLE
DetachedSpan#detachThreadLocalSpan

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/DetachedSpan.java
+++ b/tracing/src/main/java/com/palantir/tracing/DetachedSpan.java
@@ -49,6 +49,15 @@ public interface DetachedSpan {
     }
 
     /**
+     * Converts the current in-progress thread-local span into a {@link DetachedSpan}, which can be used to more easily
+     * instrument async operations. This {@link DetachedSpan} will need to be manually closed.
+     */
+    @CheckReturnValue
+    static DetachedSpan detachThreadLocalSpan() {
+        return Tracer.detachThreadLocalSpan();
+    }
+
+    /**
      * Equivalent to {@link Tracer#startSpan(String, SpanType)}, but using this {@link DetachedSpan}
      * as the parent instead of thread state.
      */


### PR DESCRIPTION
## Before this PR

@robert3005 has an async retrofit call that he wants to wrap in a span that he names himself (so that he can differentiate a couple of different possible call sites in trace-log-viewer).

This is currently not possible because the retrofit client reads the trace & span information out of _thread local_ variables, but needs to complete in an async way.

## After this PR
==COMMIT_MSG==
A new `DetachedSpan#detachThreadLocalSpan` method allows converting an in-progress thread local span into a detached span which can be used to instrument async behaviour.
==COMMIT_MSG==

before merging
- [ ] needs example usage (@robert3005?)
- [ ] tests
- [ ] decide if there's a nicer way of supporting this

## Possible downsides?

- @dansanduleac is concerned that code after this invocation will have a different parentSpanId than before, which might not be obvious to users.
- an alternative idea, is to not give users these imperative way of modifying thread local state, and instead just take in a closure?

