### PR TITLE
Tracers.wrapListenableFuture utility to wrap ListenableFutures with detached spans

### DIFF
--- a/changelog/@unreleased/pr-328.v2.yml
+++ b/changelog/@unreleased/pr-328.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Tracers.wrapListenableFuture utility to wrap ListenableFutures with
+    detached spans
+  links:
+  - https://github.com/palantir/tracing-java/pull/328

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -202,7 +202,7 @@ public final class Tracers {
         // no active trace, the detached span would not be associated with work initiated by delegateFactory.
         try (CloseableSpan ignored =
                 // This could be more efficient using https://github.com/palantir/tracing-java/issues/177
-                span.childSpan("Initial: " + operation)) {
+                span.childSpan(operation + " initial")) {
             result = Preconditions.checkNotNull(delegateFactory.get(), "Expected a ListenableFuture");
         } finally {
             if (result != null) {

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -16,11 +16,16 @@
 
 package com.palantir.tracing;
 
+import com.google.common.annotations.Beta;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.logsafe.Preconditions;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
 
 /** Utility methods for making {@link ExecutorService} and {@link Runnable} instances tracing-aware. */
 public final class Tracers {
@@ -172,6 +177,45 @@ public final class Tracers {
      */
     public static Runnable wrap(String operation, Runnable delegate) {
         return new TracingAwareRunnable(Optional.of(operation), delegate);
+    }
+
+    /**
+     * Traces the the execution of the <pre>delegateFactory</pre>, completing a span when the returned
+     * {@link ListenableFuture#isDone() ListenableFuture is done}.
+     *
+     * Example usage:
+     * <pre>{@code
+     *     ListenableFuture<Result> future = Tracers.wrapListenableFuture(
+     *         "remote operation",
+     *         () -> retrofitClient.doRequest());
+     * }</pre>
+     *
+     * Note that this function is not named <pre>wrap</pre> in order to avoid conflicting with potential utility
+     * methods for {@link Supplier suppliers}.
+     */
+    @Beta
+    public static <T, U extends ListenableFuture<T>> U wrapListenableFuture(
+            String operation, Supplier<U> delegateFactory) {
+        DetachedSpan span = DetachedSpan.start(operation);
+        U result = null;
+        // n.b. This span is required to apply tracing thread state to an initial request. Otherwise if there is
+        // no active trace, the detached span would not be associated with work initiated by delegateFactory.
+        try (CloseableSpan ignored =
+                // This could be more efficient using https://github.com/palantir/tracing-java/issues/177
+                span.childSpan("Initial: " + operation)) {
+            result = Preconditions.checkNotNull(delegateFactory.get(), "Expected a ListenableFuture");
+        } finally {
+            if (result != null) {
+                // In the successful case we add a listener in the finally block to prevent confusing traces
+                // when delegateFactory returns a completed future. This way the detached span cannot complete
+                // prior to its child.
+                result.addListener(span::complete, MoreExecutors.directExecutor());
+            } else {
+                // Complete the detached span, even if the delegateFactory throws.
+                span.complete();
+            }
+        }
+        return result;
     }
 
     /**

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -277,7 +277,7 @@ public final class TracersTest {
             // Inner operation must complete first to avoid confusion
             assertThat(observed.get(0))
                     .extracting(Span::getOperation)
-                    .isEqualTo("Initial: " + operationName);
+                    .isEqualTo(operationName + " initial");
             assertThat(observed.get(1))
                     .extracting(Span::getOperation)
                     .isEqualTo(operationName);
@@ -303,7 +303,7 @@ public final class TracersTest {
             // Inner operation must complete first to avoid confusion
             assertThat(observed.get(0))
                     .extracting(Span::getOperation)
-                    .isEqualTo("Initial: " + operationName);
+                    .isEqualTo(operationName + " initial");
             assertThat(observed.get(1))
                     .extracting(Span::getOperation)
                     .isEqualTo(operationName);
@@ -328,7 +328,7 @@ public final class TracersTest {
         assertThat(observed).hasSize(1);
         assertThat(observed.get(0))
                 .extracting(Span::getOperation)
-                .isEqualTo("Initial: " + operationName);
+                .isEqualTo(operationName + " initial");
         // Complete the future
         rawFuture.set("complete");
         assertThat(traced).isDone();
@@ -358,7 +358,7 @@ public final class TracersTest {
             assertThat(observed).hasSize(2);
             assertThat(observed.get(0))
                     .extracting(Span::getOperation)
-                    .isEqualTo("Initial: " + operationName);
+                    .isEqualTo(operationName + " initial");
             assertThat(observed.get(1))
                     .extracting(Span::getOperation)
                     .isEqualTo(operationName);

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -20,8 +20,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+import com.palantir.logsafe.exceptions.SafeNullPointerException;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.tracing.api.OpenSpan;
+import com.palantir.tracing.api.Span;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -255,6 +262,120 @@ public final class TracersTest {
         });
         runnable.run();
         assertThat(Tracer.completeSpan().get().getOperation()).isEqualTo("outside");
+    }
+
+    @Test
+    public void testWrapFuture_immediate() {
+        List<Span> observed = new ArrayList<>();
+        Tracer.subscribe("futureTest", observed::add);
+        try {
+            String operationName = "testOperation";
+            ListenableFuture<String> traced =
+                    Tracers.wrapListenableFuture(operationName, () -> Futures.immediateFuture("result"));
+            assertThat(traced).isDone();
+            assertThat(observed).hasSize(2);
+            // Inner operation must complete first to avoid confusion
+            assertThat(observed.get(0))
+                    .extracting(Span::getOperation)
+                    .isEqualTo("Initial: " + operationName);
+            assertThat(observed.get(1))
+                    .extracting(Span::getOperation)
+                    .isEqualTo(operationName);
+            assertThat(observed)
+                    .allSatisfy(span -> assertThat(span)
+                            .extracting(Span::getTraceId)
+                            .isEqualTo("defaultTraceId"));
+        } finally {
+            Tracer.unsubscribe("futureTest");
+        }
+    }
+
+    @Test
+    public void testWrapFuture_failure() {
+        List<Span> observed = new ArrayList<>();
+        Tracer.subscribe("futureTest", observed::add);
+        try {
+            String operationName = "testOperation";
+            ListenableFuture<String> traced = Tracers.wrapListenableFuture(operationName,
+                    () -> Futures.immediateFailedFuture(new SafeRuntimeException("result")));
+            assertThat(traced).isDone();
+            assertThat(observed).hasSize(2);
+            // Inner operation must complete first to avoid confusion
+            assertThat(observed.get(0))
+                    .extracting(Span::getOperation)
+                    .isEqualTo("Initial: " + operationName);
+            assertThat(observed.get(1))
+                    .extracting(Span::getOperation)
+                    .isEqualTo(operationName);
+            assertThat(observed)
+                    .allSatisfy(span -> assertThat(span)
+                            .extracting(Span::getTraceId)
+                            .isEqualTo("defaultTraceId"));
+        } finally {
+            Tracer.unsubscribe("futureTest");
+        }
+    }
+
+    @Test
+    public void testWrapFuture_delayed() {
+        List<Span> observed = new ArrayList<>();
+        Tracer.subscribe("futureTest", observed::add);
+        String operationName = "testOperation";
+        SettableFuture<String> rawFuture = SettableFuture.create();
+        SettableFuture<String> traced = Tracers.wrapListenableFuture(operationName, () -> rawFuture);
+        assertThat(traced).isNotDone();
+        // Inner operation has completed
+        assertThat(observed).hasSize(1);
+        assertThat(observed.get(0))
+                .extracting(Span::getOperation)
+                .isEqualTo("Initial: " + operationName);
+        // Complete the future
+        rawFuture.set("complete");
+        assertThat(traced).isDone();
+        assertThat(observed).hasSize(2);
+        assertThat(observed.get(1))
+                .extracting(Span::getOperation)
+                .isEqualTo(operationName);
+        assertThat(observed)
+                .allSatisfy(span -> assertThat(span)
+                        .extracting(Span::getTraceId)
+                        .isEqualTo("defaultTraceId"));
+    }
+
+    @Test
+    public void testWrapFuture_throws() {
+        List<Span> observed = new ArrayList<>();
+        Tracer.subscribe("futureTest", observed::add);
+        try {
+            String operationName = "testOperation";
+            assertThatThrownBy(() -> Tracers.wrapListenableFuture(operationName, () -> {
+                // It's best if these cases result in a failed future, but we've found these in the
+                // wild so we must handle them properly.
+                throw new SafeRuntimeException("initial operation failure");
+            }))
+                    .isInstanceOf(SafeRuntimeException.class)
+                    .hasMessage("initial operation failure");
+            assertThat(observed).hasSize(2);
+            assertThat(observed.get(0))
+                    .extracting(Span::getOperation)
+                    .isEqualTo("Initial: " + operationName);
+            assertThat(observed.get(1))
+                    .extracting(Span::getOperation)
+                    .isEqualTo(operationName);
+            assertThat(observed)
+                    .allSatisfy(span -> assertThat(span)
+                            .extracting(Span::getTraceId)
+                            .isEqualTo("defaultTraceId"));
+        } finally {
+            Tracer.unsubscribe("futureTest");
+        }
+    }
+
+    @Test
+    public void testWrapFuture_returnNull() {
+        assertThatThrownBy(() -> Tracers.wrapListenableFuture("operation", () -> null))
+                .isInstanceOf(SafeNullPointerException.class)
+                .hasMessage("Expected a ListenableFuture");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
Required one-off implementation for each consumer, with potential for confusing output and bugs. Here we have a documented utility with test coverage.

## After this PR
==COMMIT_MSG==
Tracers.wrapListenableFuture utility to wrap ListenableFutures with detached spans
==COMMIT_MSG==

