### PR TITLE
Add methods to create CloseableTracer with metadata

### DIFF
--- a/changelog/@unreleased/pr-343.v2.yml
+++ b/changelog/@unreleased/pr-343.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: CloseableTracer now supports creating spans with metadata.
+  links:
+  - https://github.com/palantir/tracing-java/pull/343


### PR DESCRIPTION
## Before this PR
It was not possible to use `CloseableTracer` and close the span with metadata.

## After this PR
It is possible to use `CloseableTracer` and close the span with metadata.

