### PR TITLE
Introduce topSpanId to disambiguate incoming requests that share traceid

### DIFF
--- a/changelog/@unreleased/pr-352.v2.yml
+++ b/changelog/@unreleased/pr-352.v2.yml
@@ -1,0 +1,7 @@
+type: feature
+feature:
+  description: Introduce a new property on a Trace, topSpanId, that can be read to
+    disambiguate span stacks that belong to the same traceid but had different entry
+    points.
+  links:
+  - https://github.com/palantir/tracing-java/pull/352

--- a/changelog/@unreleased/pr-352.v2.yml
+++ b/changelog/@unreleased/pr-352.v2.yml
@@ -1,6 +1,6 @@
 type: feature
 feature:
-  description: Introduce a new property on a Trace, topSpanId, that can be read to
+  description: Introduce a new property on a Trace, outermostSpanId, that can be read to
     disambiguate span stacks that belong to the same traceid but had different entry
     points.
   links:

--- a/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
+++ b/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
@@ -46,7 +46,7 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
      * This is the name of the trace id property we set on {@link ContainerRequestContext}.
      */
     public static final String TRACE_ID_PROPERTY_NAME = "com.palantir.tracing.traceId";
-    public static final String TOP_SPAN_ID_PROPERTY_NAME = "com.palantir.tracing.topSpanId";
+    public static final String TOP_SPAN_ID_PROPERTY_NAME = "com.palantir.tracing.outermostSpanId";
     public static final String SAMPLED_PROPERTY_NAME = "com.palantir.tracing.sampled";
 
     @Context
@@ -83,7 +83,7 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
 
         // Give asynchronous downstream handlers access to the trace id
         requestContext.setProperty(TRACE_ID_PROPERTY_NAME, Tracer.getTraceId());
-        Tracer.getTopSpanId().ifPresent(localId ->
+        Tracer.getOutermostSpanId().ifPresent(localId ->
                 requestContext.setProperty(TOP_SPAN_ID_PROPERTY_NAME, localId));
         requestContext.setProperty(SAMPLED_PROPERTY_NAME, Tracer.isTraceObservable());
     }

--- a/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
+++ b/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
@@ -46,7 +46,7 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
      * This is the name of the trace id property we set on {@link ContainerRequestContext}.
      */
     public static final String TRACE_ID_PROPERTY_NAME = "com.palantir.tracing.traceId";
-    public static final String LOCAL_TRACE_ID_PROPERTY_NAME = "com.palantir.tracing.localTraceId";
+    public static final String TOP_SPAN_ID_PROPERTY_NAME = "com.palantir.tracing.topSpanId";
     public static final String SAMPLED_PROPERTY_NAME = "com.palantir.tracing.sampled";
 
     @Context
@@ -72,8 +72,7 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
             Tracer.initTrace(getObservabilityFromHeader(requestContext), Tracers.randomId());
             Tracer.fastStartSpan(operation, SpanType.SERVER_INCOMING);
         } else {
-            // propagate the traceid from request headers, but create a new local trace id to disambiguate
-            Tracer.initTrace(getObservabilityFromHeader(requestContext), traceId, Tracers.randomId());
+            Tracer.initTrace(getObservabilityFromHeader(requestContext), traceId);
             if (spanId == null) {
                 Tracer.fastStartSpan(operation, SpanType.SERVER_INCOMING);
             } else {
@@ -84,8 +83,8 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
 
         // Give asynchronous downstream handlers access to the trace id
         requestContext.setProperty(TRACE_ID_PROPERTY_NAME, Tracer.getTraceId());
-        Tracer.getLocalTraceId().ifPresent(localId ->
-                requestContext.setProperty(LOCAL_TRACE_ID_PROPERTY_NAME, localId));
+        Tracer.getTopSpanId().ifPresent(localId ->
+                requestContext.setProperty(TOP_SPAN_ID_PROPERTY_NAME, localId));
         requestContext.setProperty(SAMPLED_PROPERTY_NAME, Tracer.isTraceObservable());
     }
 

--- a/tracing-jersey/src/test/java/com/palantir/tracing/jersey/TraceEnrichingFilterTest.java
+++ b/tracing-jersey/src/test/java/com/palantir/tracing/jersey/TraceEnrichingFilterTest.java
@@ -295,8 +295,8 @@ public final class TraceEnrichingFilterTest {
         }
 
         @Override
-        public String getTopSpanId() {
-            return Tracer.getTopSpanId().get();
+        public String getOutermostSpanId() {
+            return Tracer.getOutermostSpanId().get();
         }
 
         @Override
@@ -335,7 +335,7 @@ public final class TraceEnrichingFilterTest {
 
         @GET
         @Path("/top-span")
-        String getTopSpanId();
+        String getOutermostSpanId();
 
         @GET
         @Path("/failing-streaming-trace")

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
@@ -100,7 +100,8 @@ public final class TracedOperationHandler implements HttpHandler {
 
     /** Initializes trace state given a trace-id header from the client. */
     private void initializeTraceFromExisting(HeaderMap headers, String traceId) {
-        Tracer.initTrace(getObservabilityFromHeader(headers), traceId);
+        // propagate the traceid from request headers, but create a new local trace id to disambiguate
+        Tracer.initTrace(getObservabilityFromHeader(headers), traceId, Tracers.randomId());
         String spanId = headers.getFirst(SPAN_ID); // nullable
         if (spanId == null) {
             Tracer.fastStartSpan(operation, SpanType.SERVER_INCOMING);

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
@@ -100,8 +100,7 @@ public final class TracedOperationHandler implements HttpHandler {
 
     /** Initializes trace state given a trace-id header from the client. */
     private void initializeTraceFromExisting(HeaderMap headers, String traceId) {
-        // propagate the traceid from request headers, but create a new local trace id to disambiguate
-        Tracer.initTrace(getObservabilityFromHeader(headers), traceId, Tracers.randomId());
+        Tracer.initTrace(getObservabilityFromHeader(headers), traceId);
         String spanId = headers.getFirst(SPAN_ID); // nullable
         if (spanId == null) {
             Tracer.fastStartSpan(operation, SpanType.SERVER_INCOMING);

--- a/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedOperationHandlerTest.java
+++ b/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedOperationHandlerTest.java
@@ -110,7 +110,7 @@ public class TracedOperationHandlerTest {
         TracedOperationHandler traceSettingHandler =
                 new TracedOperationHandler(exc -> {
                     traceIdValue.set(Tracer.getTraceId());
-                    localTraceIdValue.set(Tracer.getTopSpanId().orElse(null));
+                    localTraceIdValue.set(Tracer.getOutermostSpanId().orElse(null));
 
                 }, "GET /traced");
         traceSettingHandler.handleRequest(exchange);

--- a/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedOperationHandlerTest.java
+++ b/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedOperationHandlerTest.java
@@ -110,7 +110,7 @@ public class TracedOperationHandlerTest {
         TracedOperationHandler traceSettingHandler =
                 new TracedOperationHandler(exc -> {
                     traceIdValue.set(Tracer.getTraceId());
-                    localTraceIdValue.set(Tracer.getLocalTraceId().orElse(null));
+                    localTraceIdValue.set(Tracer.getTopSpanId().orElse(null));
 
                 }, "GET /traced");
         traceSettingHandler.handleRequest(exchange);

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -236,17 +236,23 @@ public abstract class Trace {
          * This allows thread trace state to be cleared when all "started" spans have been "removed".
          */
         private int numberOfSpans;
-        private Optional<String> originatingSpanId = Optional.empty();
-        private Optional<String> topSpanId = Optional.empty();
+        private Optional<String> originatingSpanId;
+        private Optional<String> topSpanId;
 
-        private Unsampled(int numberOfSpans, String traceId) {
+        private Unsampled(
+                int numberOfSpans,
+                String traceId,
+                Optional<String> originatingSpanId,
+                Optional<String> topSpanId) {
             super(traceId);
             this.numberOfSpans = numberOfSpans;
+            this.originatingSpanId = originatingSpanId;
+            this.topSpanId = topSpanId;
             validateNumberOfSpans();
         }
 
         private Unsampled(String traceId) {
-            this(0, traceId);
+            this(0, traceId, Optional.empty(), Optional.empty());
         }
 
         @Override
@@ -269,7 +275,6 @@ public abstract class Trace {
         @Override
         protected void push(OpenSpan span) {
             if (numberOfSpans == 0) {
-                // TODO: shouldn't this be span.getOriginatingSpanId?
                 originatingSpanId = span.getParentSpanId();
                 topSpanId = Optional.of(span.getSpanId());
             }
@@ -317,8 +322,7 @@ public abstract class Trace {
 
         @Override
         Trace deepCopy() {
-            // TODO: shouldn't this preserve originatingSpanId / topSpanId?
-            return new Unsampled(numberOfSpans, getTraceId());
+            return new Unsampled(numberOfSpans, getTraceId(), getOriginatingSpanId(), getTopSpanId());
         }
 
         /** Internal validation, this should never fail because {@link #pop()} only decrements positive values. */

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -484,8 +484,8 @@ public final class Tracer {
     }
 
     /** Returns the globally unique identifier for this thread's trace specific to this call. */
-    public static Optional<String> getTopSpanId() {
-        return checkNotNull(currentTrace.get(), "There is no trace").getTopSpanId();
+    public static Optional<String> getOutermostSpanId() {
+        return checkNotNull(currentTrace.get(), "There is no trace").getOutermostSpanId();
     }
 
     /** Clears the current trace id and returns it if present. */

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -78,6 +78,15 @@ public final class Tracer {
         return Trace.of(observable, traceId);
     }
 
+    /**
+     * Creates a new localized trace, but does not set it as the current trace.
+     */
+    private static Trace createTrace(Observability observability, String traceId, String localTraceId) {
+        checkArgument(!Strings.isNullOrEmpty(traceId), "traceId must be non-empty");
+        boolean observable = shouldObserve(observability);
+        return Trace.of(observable, traceId, localTraceId);
+    }
+
     private static boolean shouldObserve(Observability observability) {
         switch (observability) {
             case SAMPLE:
@@ -137,6 +146,13 @@ public final class Tracer {
      */
     public static void initTrace(Observability observability, String traceId) {
         setTrace(createTrace(observability, traceId));
+    }
+
+    /**
+     * Initializes the current thread's trace, erasing any previously accrued open spans.
+     */
+    public static void initTrace(Observability observability, String traceId, String localTraceId) {
+        setTrace(createTrace(observability, traceId, localTraceId));
     }
 
     /**
@@ -481,6 +497,11 @@ public final class Tracer {
     /** Returns the globally unique identifier for this thread's trace. */
     public static String getTraceId() {
         return checkNotNull(currentTrace.get(), "There is no trace").getTraceId();
+    }
+
+    /** Returns the globally unique identifier for this thread's trace specific to this call. */
+    public static Optional<String> getLocalTraceId() {
+        return checkNotNull(currentTrace.get(), "There is no trace").getLocalTraceId();
     }
 
     /** Clears the current trace id and returns it if present. */

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -78,15 +78,6 @@ public final class Tracer {
         return Trace.of(observable, traceId);
     }
 
-    /**
-     * Creates a new localized trace, but does not set it as the current trace.
-     */
-    private static Trace createTrace(Observability observability, String traceId, String localTraceId) {
-        checkArgument(!Strings.isNullOrEmpty(traceId), "traceId must be non-empty");
-        boolean observable = shouldObserve(observability);
-        return Trace.of(observable, traceId, localTraceId);
-    }
-
     private static boolean shouldObserve(Observability observability) {
         switch (observability) {
             case SAMPLE:
@@ -146,13 +137,6 @@ public final class Tracer {
      */
     public static void initTrace(Observability observability, String traceId) {
         setTrace(createTrace(observability, traceId));
-    }
-
-    /**
-     * Initializes the current thread's trace, erasing any previously accrued open spans.
-     */
-    public static void initTrace(Observability observability, String traceId, String localTraceId) {
-        setTrace(createTrace(observability, traceId, localTraceId));
     }
 
     /**
@@ -500,8 +484,8 @@ public final class Tracer {
     }
 
     /** Returns the globally unique identifier for this thread's trace specific to this call. */
-    public static Optional<String> getLocalTraceId() {
-        return checkNotNull(currentTrace.get(), "There is no trace").getLocalTraceId();
+    public static Optional<String> getTopSpanId() {
+        return checkNotNull(currentTrace.get(), "There is no trace").getTopSpanId();
     }
 
     /** Clears the current trace id and returns it if present. */


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Logs from concurrent incoming requests with the same traceid are currently difficult
to tell apart (one can look at thread names etc, but not across executors).

## After this PR
==COMMIT_MSG==
This introduces a new optional property on a Trace, topSpanId, that can be read to disambiguate span stacks that belong to the same traceid bug had different entry points.

Use that in tracing-undertow and tracing-jersey to tell apart requests with the same traceid.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
The unsampled span has to keep a bit more state (not just the parent of the top span as per originating span id, but also the top span id).
We have to generate a new span id in unsampled spans if the stack is empty.