### PR TITLE
Scheduled executor recurring tasks are always given new trace IDs

### DIFF
--- a/changelog/@unreleased/pr-362.v2.yml
+++ b/changelog/@unreleased/pr-362.v2.yml
@@ -1,0 +1,26 @@
+type: break
+break:
+  description: |-
+    Scheduled executor recurring tasks are always given new trace IDs
+
+    Previously we had no good options for scheduled executors: Either
+    create a new traceId for every taskd regardless of whether it was
+    submitted to execute(runnable) or scheduleWithFixedDelay which
+    mean very different things.
+
+    Recurring tasks are most frequently scheduled on application startup
+    and continue to execute at a cadence until the service is halted.
+    In these cases we used to produce large traces bounded by the
+    runtime of the application, making the traceId of an error thrown
+    in this context unhelpful for debugging. In worse cases, lazily
+    scheduled tasks are created with the traceId of a request that
+    happened to cause lazy initialization, resulting in tracing state
+    that incorrectly blames to a particular user request.
+
+    While there are cases that we may want to preserve a single traceId
+    across a scheduled task, they are sparse and complex. In these cases
+    it's reasonable to expect developers to wrap tasks before scheduling
+    them with an executor to acknowledge the desired behavior, and make
+    it clear to others who read the code.
+  links:
+  - https://github.com/palantir/tracing-java/pull/362

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -117,6 +117,11 @@ public final class Tracers {
     public static ScheduledExecutorService wrap(ScheduledExecutorService executorService) {
         return new WrappingScheduledExecutorService(executorService) {
             @Override
+            protected Runnable wrapRecurring(Runnable runnable) {
+                return wrapWithNewTrace(runnable);
+            }
+
+            @Override
             protected <T> Callable<T> wrapTask(Callable<T> callable) {
                 return wrap(callable);
             }
@@ -135,6 +140,11 @@ public final class Tracers {
     public static ScheduledExecutorService wrap(String operation,
             ScheduledExecutorService executorService) {
         return new WrappingScheduledExecutorService(executorService) {
+            @Override
+            protected Runnable wrapRecurring(Runnable runnable) {
+                return wrapWithNewTrace(operation, runnable);
+            }
+
             @Override
             protected <T> Callable<T> wrapTask(Callable<T> callable) {
                 return wrap(operation, callable);
@@ -269,6 +279,11 @@ public final class Tracers {
     public static ScheduledExecutorService wrapWithNewTrace(String operation,
             ScheduledExecutorService executorService) {
         return new WrappingScheduledExecutorService(executorService) {
+            @Override
+            protected Runnable wrapRecurring(Runnable runnable) {
+                return wrapTask(runnable);
+            }
+
             @Override
             protected <T> Callable<T> wrapTask(Callable<T> callable) {
                 return wrapWithNewTrace(operation, callable);

--- a/tracing/src/main/java/com/palantir/tracing/WrappingScheduledExecutorService.java
+++ b/tracing/src/main/java/com/palantir/tracing/WrappingScheduledExecutorService.java
@@ -50,12 +50,19 @@ abstract class WrappingScheduledExecutorService extends WrappingExecutorService
     @Override
     public final ScheduledFuture<?> scheduleAtFixedRate(
             Runnable command, long initialDelay, long period, TimeUnit unit) {
-        return delegate.scheduleAtFixedRate(wrapTask(command), initialDelay, period, unit);
+        return delegate.scheduleAtFixedRate(wrapRecurring(command), initialDelay, period, unit);
     }
 
     @Override
     public final ScheduledFuture<?> scheduleWithFixedDelay(
             Runnable command, long initialDelay, long delay, TimeUnit unit) {
-        return delegate.scheduleWithFixedDelay(wrapTask(command), initialDelay, delay, unit);
+        return delegate.scheduleWithFixedDelay(wrapRecurring(command), initialDelay, delay, unit);
     }
+
+    /**
+     * Wraps a task that may be executed multiple times, perhaps using
+     * {@link #scheduleAtFixedRate(Runnable, long, long, TimeUnit)} or
+     * {@link #scheduleWithFixedDelay(Runnable, long, long, TimeUnit)}.
+     */
+    protected abstract Runnable wrapRecurring(Runnable runnable);
 }


### PR DESCRIPTION
==COMMIT_MSG==
Previously we had no good options for scheduled executors: Either
create a new traceId for every taskd regardless of whether it was
submitted to execute(runnable) or scheduleWithFixedDelay which
mean very different things.

Recurring tasks are most frequently scheduled on application startup
and continue to execute at a cadence until the service is halted.
In these cases we used to produce large traces bounded by the
runtime of the application, making the traceId of an error thrown
in this context unhelpful for debugging. In worse cases, lazily
scheduled tasks are created with the traceId of a request that
happened to cause lazy initialization, resulting in tracing state
that incorrectly blames to a particular user request.

While there are cases that we may want to preserve a single traceId
across a scheduled task, they are sparse and complex. In these cases
it's reasonable to expect developers to wrap tasks before scheduling
them with an executor to acknowledge the desired behavior, and make
it clear to others who read the code.
==COMMIT_MSG==

## Possible downsides?
Risk for cases where a single traceId is expected across recurring tasks.
This is justifiable because there are very few of these (none that I am
personally aware of) and many cases that are fixed by this change.

While there are cases that we may want to preserve a single traceId
across a scheduled task, they are sparse and complex. In these cases
it's reasonable to expect developers to wrap tasks before scheduling
them with an executor to acknowledge the desired behavior, and make
it clear to others who read the code.

