### PR TITLE
Introduce requestId MDC property

### DIFF
--- a/changelog/@unreleased/pr-364.v2.yml
+++ b/changelog/@unreleased/pr-364.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Introduce a new MDC property, _requestId, that disambiguates span stacks
+    that belong to the same traceid but are different requests.
+  links:
+  - https://github.com/palantir/tracing-java/pull/364

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -35,6 +35,12 @@ public final class Tracers {
      * field can take the values of "1" or "0", where "1" indicates the trace was sampled.
      */
     public static final String TRACE_SAMPLED_KEY = "_sampled";
+    /**
+     * The key under which the outermost span ids are inserted into SLF4J {@link org.slf4j.MDC MDCs}.
+     * It is present only if the outermost span of the current trace is a SERVER_INCOMING span, and can be used
+     * to distinguish between incoming requests with the same traceid header.
+     */
+    public static final String REQUEST_ID_KEY = "_requestId";
     private static final String DEFAULT_ROOT_SPAN_OPERATION = "root";
     private static final char[] HEX_DIGITS =
             {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};


### PR DESCRIPTION
Logs from concurrent incoming requests with the same traceid are currently difficult
to tell apart (one can look at thread names etc, but not across executors).

## After this PR
==COMMIT_MSG==
Introduce a new MDC property managed by Tracers, which stores a unique identifier
when the top span of the current trace is a SERVER_INCOMING span.
==COMMIT_MSG==


## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

