### PR TITLE
New endpoint to wrap Callable with alternative trace ID

### DIFF
--- a/changelog/@unreleased/pr-375.v2.yml
+++ b/changelog/@unreleased/pr-375.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: <!-- User-facing outcomes this PR delivers -->
+  links:
+  - https://github.com/palantir/tracing-java/pull/375

--- a/changelog/@unreleased/pr-375.v2.yml
+++ b/changelog/@unreleased/pr-375.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
   description:
-    A new endpoint to support wrapping Callables with alternative trace ID is added.
+    Add a new endpoint to support wrapping Callables with alternative trace ID.
   links:
   - https://github.com/palantir/tracing-java/pull/375

--- a/changelog/@unreleased/pr-375.v2.yml
+++ b/changelog/@unreleased/pr-375.v2.yml
@@ -1,5 +1,6 @@
 type: improvement
 improvement:
-  description: <!-- User-facing outcomes this PR delivers -->
+  description:
+    A new endpoint to support wrapping Callables with alternative trace ID is added.
   links:
   - https://github.com/palantir/tracing-java/pull/375

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -406,7 +406,7 @@ public final class Tracers {
     public static Runnable wrapWithAlternateTraceId(String traceId, String operation, Runnable delegate) {
         return wrapWithAlternateTraceId(traceId, operation, Observability.UNDECIDED, delegate);
     }
-/*
+
     /**
      * Wraps the given {@link Runnable} such that it creates a fresh {@link Trace tracing state with the given traceId}
      * for its execution. That is, the trace during its {@link Runnable#run() execution} will use the traceId provided

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -334,6 +334,30 @@ public final class Tracers {
     }
 
     /**
+     * Wraps the given {@link Callable} such that it creates a fresh {@link Trace tracing state with the given traceId}
+     * for its execution. That is, the trace during its {@link Callable#call() execution} will use the traceId provided
+     * instead of any trace already set on the thread used to execute the callable. Each execution of the callable
+     * will use a new {@link Trace tracing state} with the same given traceId. The given {@link String operation} is
+     * used to create the initial span.
+     */
+    public static <V> Callable<V> wrapWithAlternateTraceId(String traceId, String operation,
+            Observability observability, Callable<V> delegate) {
+        return () -> {
+            // clear the existing trace and keep it around for restoration when we're done
+            Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
+
+            try {
+                Tracer.initTrace(observability, traceId);
+                Tracer.fastStartSpan(operation);
+                return delegate.call();
+            } finally {
+                Tracer.fastCompleteSpan();
+                restoreTrace(originalTrace);
+            }
+        };
+    }
+
+    /**
      * Deprecated.
      *
      * @deprecated Use {@link #wrapWithNewTrace(String, Runnable)}
@@ -382,7 +406,7 @@ public final class Tracers {
     public static Runnable wrapWithAlternateTraceId(String traceId, String operation, Runnable delegate) {
         return wrapWithAlternateTraceId(traceId, operation, Observability.UNDECIDED, delegate);
     }
-
+/*
     /**
      * Wraps the given {@link Runnable} such that it creates a fresh {@link Trace tracing state with the given traceId}
      * for its execution. That is, the trace during its {@link Runnable#run() execution} will use the traceId provided

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -546,7 +546,7 @@ public final class TracersTest {
     }
 
     @Test
-    public void testWrapCallableWithAlternateTraceId_traceStateInsideRunnableHasSpan() throws Exception {
+    public void testWrapCallableWithAlternateTraceId_traceStateInsideCallableHasSpan() throws Exception {
         String traceIdToUse = "someTraceId";
         Callable<List<OpenSpan>> wrappedCallable = Tracers.wrapWithAlternateTraceId(
                 traceIdToUse,

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -522,6 +522,101 @@ public final class TracersTest {
         assertThat(unSampledCallable.call()).isFalse();
     }
 
+
+    @Test
+    public void testWrapCallableWithAlternateTraceId_traceStateInsideCallableUsesGivenTraceId() throws Exception {
+        String traceIdBeforeConstruction = Tracer.getTraceId();
+        String traceIdToUse = "someTraceId";
+        Callable<String> wrappedCallable = Tracers.wrapWithAlternateTraceId(
+                traceIdToUse,
+                "operation",
+                Observability.UNDECIDED,
+                () -> Tracer.getTraceId());
+
+        String traceIdInsideCallable = wrappedCallable.call();
+
+        String traceIdAfterCall = Tracer.getTraceId();
+
+        assertThat(traceIdInsideCallable)
+                .isNotEqualTo(traceIdBeforeConstruction)
+                .isNotEqualTo(traceIdAfterCall)
+                .isEqualTo(traceIdToUse);
+
+        assertThat(traceIdBeforeConstruction).isEqualTo(traceIdAfterCall);
+    }
+
+    @Test
+    public void testWrapCallableWithAlternateTraceId_traceStateInsideRunnableHasSpan() throws Exception {
+        String traceIdToUse = "someTraceId";
+        Callable<List<OpenSpan>> wrappedCallable = Tracers.wrapWithAlternateTraceId(
+                traceIdToUse,
+                "operation",
+                Observability.UNDECIDED,
+                TracersTest::getCurrentTrace);
+
+        List<OpenSpan> spans = wrappedCallable.call();
+
+        assertThat(spans).hasSize(1);
+
+        OpenSpan span = spans.get(0);
+
+        assertThat(span.getOperation()).isEqualTo("operation");
+        assertThat(span.getParentSpanId()).isEmpty();
+    }
+
+    @Test
+    public void testWrapCallableWithAlternateTraceId_traceStateRestoredWhenThrows() {
+        String traceIdBeforeConstruction = Tracer.getTraceId();
+        Callable rawCallable = () -> {
+            throw new IllegalStateException();
+        };
+        Callable wrappedCallable = Tracers.wrapWithAlternateTraceId(
+                "someTraceId",
+                "operation",
+                Observability.UNDECIDED,
+                rawCallable);
+
+        assertThatThrownBy(() -> wrappedCallable.call()).isInstanceOf(IllegalStateException.class);
+        assertThat(Tracer.getTraceId()).isEqualTo(traceIdBeforeConstruction);
+    }
+
+    @Test
+    public void testWrapCallableWithAlternateTraceId_traceStateRestoredToCleared() throws Exception {
+        // Clear out the default initialized trace
+        Tracer.getAndClearTraceIfPresent();
+        Tracers.wrapWithAlternateTraceId(
+                "someTraceId",
+                "operation",
+                Observability.UNDECIDED,
+                () -> {
+                    // no-op
+                    return null;
+                }).call();
+        assertThat(Tracer.hasTraceId()).isFalse();
+    }
+
+    @Test
+    public void testWrapCallableWithAlternateTraceId_canSpecifyObservability() throws Exception {
+        Callable sampledCallable = () -> assertThat(Tracer.copyTrace().get().isObservable()).isTrue();
+        Callable wrappedSampledCallable = Tracers.wrapWithAlternateTraceId(
+                "someTraceId",
+                "operation",
+                Observability.SAMPLE,
+                sampledCallable);
+
+        wrappedSampledCallable.call();
+
+        Callable unSampledCallable = () -> assertThat(Tracer.copyTrace().get().isObservable()).isFalse();
+        Callable wrappedUnSampledCallable = Tracers.wrapWithAlternateTraceId(
+                "someTraceId",
+                "operation",
+                Observability.DO_NOT_SAMPLE,
+                unSampledCallable);
+
+        wrappedUnSampledCallable.call();
+    }
+
+
     @Test
     public void testWrapRunnableWithNewTrace_traceStateInsideRunnableIsIsolated() throws Exception {
         String traceIdBeforeConstruction = Tracer.getTraceId();
@@ -716,21 +811,23 @@ public final class TracersTest {
 
     @Test
     public void testWrapRunnableWithAlternateTraceId_canSpecifyObservability() {
-        Runnable sampledRunnable = Tracers.wrapWithAlternateTraceId(
+        Runnable sampledRunnable = () -> assertThat(Tracer.copyTrace().get().isObservable()).isTrue();
+        Runnable wrappedSampledRunnable = Tracers.wrapWithAlternateTraceId(
                 "someTraceId",
                 "operation",
                 Observability.SAMPLE,
-                () -> assertThat(Tracer.copyTrace().get().isObservable()).isTrue());
+                sampledRunnable);
 
-        sampledRunnable.run();
+        wrappedSampledRunnable.run();
 
-        Runnable unSampledRunnable = Tracers.wrapWithAlternateTraceId(
+        Runnable unSampledRunnable = () -> assertThat(Tracer.copyTrace().get().isObservable()).isFalse();
+        Runnable wrappedUnSampledRunnable = Tracers.wrapWithAlternateTraceId(
                 "someTraceId",
                 "operation",
                 Observability.DO_NOT_SAMPLE,
-                () -> assertThat(Tracer.copyTrace().get().isObservable()).isFalse());
+                unSampledRunnable);
 
-        unSampledRunnable.run();
+        wrappedUnSampledRunnable.run();
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Currently there is no endpoint to wrap callables with provided trace ID, only for runnable

## After this PR
A new endpoint to support wrapping Callables with alternative trace ID is added

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
There can be issue with type inference with existing usage of wrapWithAlternativeTraceId -> if the current passed in runnable has returned value, then now it will be inferred as Callable and can be treated as a break
