### PR TITLE
Improvement: Make Tracer#getTraceMetadata public

### DIFF
--- a/changelog/@unreleased/pr-387.v2.yml
+++ b/changelog/@unreleased/pr-387.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Make Tracer#getTraceMetadata public to allow third party libraries
+    to propagate trace related ids
+  links:
+  - https://github.com/palantir/tracing-java/pull/387

--- a/tracing-okhttp3/src/main/java/com/palantir/tracing/OkhttpTraceInterceptor2.java
+++ b/tracing-okhttp3/src/main/java/com/palantir/tracing/OkhttpTraceInterceptor2.java
@@ -20,7 +20,6 @@ import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.tracing.api.TraceHttpHeaders;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Optional;
 import java.util.function.Function;
 import okhttp3.Interceptor;
 import okhttp3.Request;

--- a/tracing-okhttp3/src/main/java/com/palantir/tracing/OkhttpTraceInterceptor2.java
+++ b/tracing-okhttp3/src/main/java/com/palantir/tracing/OkhttpTraceInterceptor2.java
@@ -16,9 +16,11 @@
 
 package com.palantir.tracing;
 
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.tracing.api.TraceHttpHeaders;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.function.Function;
 import okhttp3.Interceptor;
 import okhttp3.Request;
@@ -43,7 +45,8 @@ public final class OkhttpTraceInterceptor2 implements Interceptor {
         Request request = chain.request();
 
         try (Closeable span = createNetworkCallSpan.apply(request)) {
-            TraceMetadata metadata = Tracer.getTraceMetadata();
+            TraceMetadata metadata = Tracer.maybeGetTraceMetadata()
+                    .orElseThrow(() -> new SafeRuntimeException("Trace with no spans in progress"));
 
             Request.Builder tracedRequest = request
                     .newBuilder()

--- a/tracing/src/main/java/com/palantir/tracing/TraceMetadata.java
+++ b/tracing/src/main/java/com/palantir/tracing/TraceMetadata.java
@@ -16,12 +16,10 @@
 
 package com.palantir.tracing;
 
-import com.google.common.annotations.Beta;
 import java.util.Optional;
 import org.immutables.value.Value;
 
 /** Ids necessary to write headers onto network requests. */
-@Beta
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
 public interface TraceMetadata {

--- a/tracing/src/main/java/com/palantir/tracing/TraceMetadata.java
+++ b/tracing/src/main/java/com/palantir/tracing/TraceMetadata.java
@@ -24,7 +24,7 @@ import org.immutables.value.Value;
 @Beta
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
-interface TraceMetadata {
+public interface TraceMetadata {
 
     /** Corresponds to {@link com.palantir.tracing.api.TraceHttpHeaders#TRACE_ID}. */
     String getTraceId();

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -97,7 +97,6 @@ public final class Tracer {
      * <p>
      * n.b. this is a bit funky because calling getTraceMetadata multiple times will return different spanIds
      */
-    @Beta
     public static TraceMetadata getTraceMetadata() {
         Trace trace = checkNotNull(currentTrace.get(), "Unable to getTraceMetadata when there is trace in progress");
 

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -92,23 +92,22 @@ public final class Tracer {
     }
 
     /**
-     * In the unsampled case, the Trace.Unsampled class doesn't actually store a spanId/parentSpanId
-     * stack, so we just make one up (just in time). This matches the behaviour of Tracer#startSpan.
+     * In the unsampled case, the Trace.Unsampled class doesn't actually store a spanId/parentSpanId stack, so we just
+     * make one up (just in time). This matches the behaviour of Tracer#startSpan.
      * <p>
-     * n.b. this is a bit funky because calling getTraceMetadata multiple times will return different spanIds
+     * n.b. this is a bit funky because calling maybeGetTraceMetadata multiple times will return different spanIds
      */
-    public static TraceMetadata getTraceMetadata() {
+    public static Optional<TraceMetadata> maybeGetTraceMetadata() {
         Trace trace = checkNotNull(currentTrace.get(), "Unable to getTraceMetadata when there is trace in progress");
 
         if (trace.isObservable()) {
-            OpenSpan openSpan = trace.top()
-                    .orElseThrow(() -> new SafeRuntimeException("Trace with no spans in progress"));
-            return TraceMetadata.builder()
-                    .spanId(openSpan.getSpanId())
-                    .parentSpanId(openSpan.getParentSpanId())
-                    .originatingSpanId(trace.getOriginatingSpanId())
-                    .traceId(trace.getTraceId())
-                    .build();
+            return trace.top()
+                    .map(openSpan -> TraceMetadata.builder()
+                            .spanId(openSpan.getSpanId())
+                            .parentSpanId(openSpan.getParentSpanId())
+                            .originatingSpanId(trace.getOriginatingSpanId())
+                            .traceId(trace.getTraceId())
+                            .build());
         } else {
             return TraceMetadata.builder()
                     .spanId(Tracers.randomId())

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -96,7 +96,10 @@ public final class Tracer {
      * n.b. this is a bit funky because calling maybeGetTraceMetadata multiple times will return different spanIds
      */
     public static Optional<TraceMetadata> maybeGetTraceMetadata() {
-        Trace trace = checkNotNull(currentTrace.get(), "Unable to getTraceMetadata when there is trace in progress");
+        Trace trace = currentTrace.get();
+        if (trace == null) {
+            return Optional.empty();
+        }
 
         if (trace.isObservable()) {
             return trace.top()

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -92,7 +92,7 @@ public final class Tracer {
     }
 
     @Beta
-    static TraceMetadata getTraceMetadata() {
+    public static TraceMetadata getTraceMetadata() {
         Trace trace = checkNotNull(currentTrace.get(), "Unable to getTraceMetadata when there is trace in progress");
 
         if (trace.isObservable()) {

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -109,12 +109,12 @@ public final class Tracer {
                             .traceId(trace.getTraceId())
                             .build());
         } else {
-            return TraceMetadata.builder()
+            return Optional.of(TraceMetadata.builder()
                     .spanId(Tracers.randomId())
                     .parentSpanId(Optional.empty())
                     .originatingSpanId(trace.getOriginatingSpanId())
                     .traceId(trace.getTraceId())
-                    .build();
+                    .build());
         }
     }
 

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -20,7 +20,6 @@ import static com.palantir.logsafe.Preconditions.checkArgument;
 import static com.palantir.logsafe.Preconditions.checkNotNull;
 import static com.palantir.logsafe.Preconditions.checkState;
 
-import com.google.common.annotations.Beta;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.errorprone.annotations.CheckReturnValue;
@@ -29,7 +28,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
-import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.tracing.api.OpenSpan;
 import com.palantir.tracing.api.Span;
 import com.palantir.tracing.api.SpanObserver;

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -91,6 +91,12 @@ public final class Tracer {
         throw new SafeIllegalArgumentException("Unknown observability", SafeArg.of("observability", observability));
     }
 
+    /**
+     * In the unsampled case, the Trace.Unsampled class doesn't actually store a spanId/parentSpanId
+     * stack, so we just make one up (just in time). This matches the behaviour of Tracer#startSpan.
+     * <p>
+     * n.b. this is a bit funky because calling getTraceMetadata multiple times will return different spanIds
+     */
     @Beta
     public static TraceMetadata getTraceMetadata() {
         Trace trace = checkNotNull(currentTrace.get(), "Unable to getTraceMetadata when there is trace in progress");
@@ -105,10 +111,6 @@ public final class Tracer {
                     .traceId(trace.getTraceId())
                     .build();
         } else {
-            // In the unsampled case, the Trace.Unsampled class doesn't actually store a spanId/parentSpanId
-            // stack, so we just make one up (just in time). This matches the behaviour of Tracer#startSpan.
-
-            // n.b. this is a bit funky because calling getTraceMetadata multiple times will return different spanIds
             return TraceMetadata.builder()
                     .spanId(Tracers.randomId())
                     .parentSpanId(Optional.empty())


### PR DESCRIPTION
## Before this PR
It's hard/impossible to integrate tracing with non okhttp http libraries as there's no way to access the same metadata as okhttptraceinterceptor has access to.

## After this PR
==COMMIT_MSG==
Make Tracer#getTraceMetadata public to allow third party libraries to propagate trace related ids
==COMMIT_MSG==

## Possible downsides?
We add yet another thing to the api surface

cc @markelliot 

