### PR TITLE
Fix ABI break on getTraceMetadata

### DIFF
--- a/changelog/@unreleased/pr-395.v2.yml
+++ b/changelog/@unreleased/pr-395.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Prevent `NoSuchMethodError` on `Tracer.getTraceMetadata` caused by
+    ABI break when using `tracing-okhttp` <=4.1.0 and `tracing` 4.2.0.
+  links:
+  - https://github.com/palantir/tracing-java/pull/395

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -28,6 +28,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.tracing.api.OpenSpan;
 import com.palantir.tracing.api.Span;
 import com.palantir.tracing.api.SpanObserver;
@@ -87,6 +88,16 @@ public final class Tracer {
         }
 
         throw new SafeIllegalArgumentException("Unknown observability", SafeArg.of("observability", observability));
+    }
+
+    /**
+     * Deprecated. This exists to avoid ABI breaks due to a cross-jar package private call that existed in <=4.1.0.
+     * @deprecated Use {@link Tracer#maybeGetTraceMetadata()} instead.
+     */
+    @Deprecated
+    static TraceMetadata getTraceMetadata() {
+        return maybeGetTraceMetadata()
+                .orElseThrow(() -> new SafeRuntimeException("Trace with no spans in progress"));
     }
 
     /**


### PR DESCRIPTION
## Before this PR
Since `getTraceMetadata` was removed in 4.2.0 (#387), unfortunately even though it is package-private there was a cross-jar call between `tracing-okhttp` and `tracing`, which meant that if `tracing-okhttp` is at 4.1.0 and `tracing` is at 4.2.0, you would get a `NoSuchMethodException`:

```
Caused by: java.lang.NoSuchMethodError: com.palantir.tracing.Tracer.getTraceMetadata()Lcom/palantir/tracing/TraceMetadata;
	at com.palantir.tracing.OkhttpTraceInterceptor2.intercept(OkhttpTraceInterceptor2.java:46)
```

Even with GCV working as expected, we are not protected from this problem.

## After this PR
The `getTraceMetadata` method has been added back to prevent this break.

==COMMIT_MSG==
Prevent `NoSuchMethodError` on `Tracer.getTraceMetadata` caused by ABI break when using `tracing-okhttp` <=4.1.0 and `tracing` 4.2.0.
==COMMIT_MSG==

## Possible downsides?
Keeping methods around to avoid ABI breaks on package private methods is super weird, and very tricky. Maybe we should prevent cross-jar package private calls in future?

cc @mglazer 