### PR TITLE
Provide Tracing support for the full request lifecycle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
         classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:14.1.1'
-        classpath 'com.palantir.baseline:gradle-baseline-java:2.49.0'
+        classpath 'com.palantir.baseline:gradle-baseline-java:2.49.1'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.2'
         classpath 'gradle.plugin.org.inferred:gradle-processors:3.2.0'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:1.15.0'

--- a/changelog/@unreleased/pr-400.v2.yml
+++ b/changelog/@unreleased/pr-400.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Provide Tracing support for the full Undertow request lifecycle
+  links:
+  - https://github.com/palantir/tracing-java/pull/400

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
@@ -18,17 +18,11 @@ package com.palantir.tracing.undertow;
 
 import static com.palantir.logsafe.Preconditions.checkNotNull;
 
-import com.google.common.base.Strings;
-import com.palantir.tracing.Observability;
-import com.palantir.tracing.Tracer;
-import com.palantir.tracing.Tracers;
-import com.palantir.tracing.api.SpanType;
-import com.palantir.tracing.api.TraceHttpHeaders;
+import com.palantir.tracing.CloseableSpan;
+import com.palantir.tracing.DetachedSpan;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.AttachmentKey;
-import io.undertow.util.HeaderMap;
-import io.undertow.util.HttpString;
 
 /**
  * Extracts Zipkin-style trace information from the given HTTP request and sets up a corresponding {@link
@@ -41,12 +35,12 @@ import io.undertow.util.HttpString;
  * handler may register.
  */
 public final class TracedOperationHandler implements HttpHandler {
-    /** Attachment to check whether the current request is being traced. */
-    public static final AttachmentKey<Boolean> IS_SAMPLED_ATTACHMENT = AttachmentKey.create(Boolean.class);
-
-    private static final HttpString TRACE_ID = HttpString.tryFromString(TraceHttpHeaders.TRACE_ID);
-    private static final HttpString SPAN_ID = HttpString.tryFromString(TraceHttpHeaders.SPAN_ID);
-    private static final HttpString IS_SAMPLED = HttpString.tryFromString(TraceHttpHeaders.IS_SAMPLED);
+    /**
+     * Attachment to check whether the current request is being traced.
+     * @deprecated in favor of {@link TracingAttachments#IS_SAMPLED}
+     */
+    @Deprecated
+    public static final AttachmentKey<Boolean> IS_SAMPLED_ATTACHMENT = TracingAttachments.IS_SAMPLED;
 
     private final String operation;
     private final HttpHandler delegate;
@@ -58,63 +52,10 @@ public final class TracedOperationHandler implements HttpHandler {
 
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
-        String traceId = initializeTrace(exchange);
-
-        // Populate response before calling delegate since delegate might commit the response.
-        exchange.getResponseHeaders().put(TRACE_ID, traceId);
-        exchange.putAttachment(IS_SAMPLED_ATTACHMENT, Tracer.isTraceObservable());
-        try {
+        DetachedSpan detachedSpan = UndertowTracing.getOrInitializeRequestTrace(exchange);
+        try (CloseableSpan ignored = detachedSpan.childSpan(operation)) {
             delegate.handleRequest(exchange);
-        } finally {
-            Tracer.fastCompleteSpan();
         }
-    }
-
-    // Force sample iff the context contains a "1" X-B3-Sampled header, force not sample if the header contains another
-    // non-empty value, or undecided if there is no such header or the header is empty.
-    private static Observability getObservabilityFromHeader(HeaderMap headers) {
-        String header = headers.getFirst(IS_SAMPLED);
-        if (Strings.isNullOrEmpty(header)) {
-            return Observability.UNDECIDED;
-        } else {
-            return "1".equals(header) ? Observability.SAMPLE : Observability.DO_NOT_SAMPLE;
-        }
-    }
-
-    /** Initializes trace state and a root span for this request, returning the traceId. */
-    private String initializeTrace(HttpServerExchange exchange) {
-        HeaderMap headers = exchange.getRequestHeaders();
-        // TODO(rfink): Log/warn if we find multiple headers?
-        String traceId = headers.getFirst(TRACE_ID); // nullable
-
-        // Set up thread-local span that inherits state from HTTP headers
-        if (Strings.isNullOrEmpty(traceId)) {
-            return initializeNewTrace(headers);
-        } else {
-            initializeTraceFromExisting(headers, traceId);
-        }
-        return traceId;
-    }
-
-    /** Initializes trace state given a trace-id header from the client. */
-    private void initializeTraceFromExisting(HeaderMap headers, String traceId) {
-        Tracer.initTrace(getObservabilityFromHeader(headers), traceId);
-        String spanId = headers.getFirst(SPAN_ID); // nullable
-        if (spanId == null) {
-            Tracer.fastStartSpan(operation, SpanType.SERVER_INCOMING);
-        } else {
-            // caller's span is this span's parent.
-            Tracer.fastStartSpan(operation, spanId, SpanType.SERVER_INCOMING);
-        }
-    }
-
-    /** Initializes trace state for a request without tracing headers. */
-    private String initializeNewTrace(HeaderMap headers) {
-        // HTTP request did not indicate a trace; initialize trace state and create a span.
-        String newTraceId = Tracers.randomId();
-        Tracer.initTrace(getObservabilityFromHeader(headers), newTraceId);
-        Tracer.fastStartSpan(operation, SpanType.SERVER_INCOMING);
-        return newTraceId;
     }
 
     @Override

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedRequestHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedRequestHandler.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tracing.undertow;
+
+import com.palantir.tracing.DetachedSpan;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+
+/**
+ * Extracts Zipkin-style trace information from the given HTTP request and sets up a corresponding {@link
+ * DetachedSpan} to span the entire request.
+ * See <a href="https://github.com/openzipkin/b3-propagation">b3-propagation</a>.
+ *
+ * This handler should be registered as early as possible in the request lifecycle to fully encapsulate
+ * all work.
+ */
+public final class TracedRequestHandler implements HttpHandler {
+
+    private final HttpHandler delegate;
+
+    public TracedRequestHandler(HttpHandler delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        UndertowTracing.getOrInitializeRequestTrace(exchange);
+        delegate.handleRequest(exchange);
+    }
+}

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedRequestHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedRequestHandler.java
@@ -27,6 +27,9 @@ import io.undertow.server.HttpServerExchange;
  *
  * This handler should be registered as early as possible in the request lifecycle to fully encapsulate
  * all work.
+ *
+ * If this handler is registered multiple times in the handler chain, subsequent executions are
+ * ignored to preserve the first, most accurate span.
  */
 public final class TracedRequestHandler implements HttpHandler {
 
@@ -40,5 +43,10 @@ public final class TracedRequestHandler implements HttpHandler {
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         UndertowTracing.getOrInitializeRequestTrace(exchange);
         delegate.handleRequest(exchange);
+    }
+
+    @Override
+    public String toString() {
+        return "TracedRequestHandler{delegate=" + delegate + '}';
     }
 }

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracingAttachments.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracingAttachments.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tracing.undertow;
+
+import io.undertow.util.AttachmentKey;
+
+/** Provides public tracing {@link AttachmentKey attachment keys}. */
+public final class TracingAttachments {
+
+    /** Attachment to check whether the current request is being traced. */
+    public static final AttachmentKey<Boolean> IS_SAMPLED = AttachmentKey.create(Boolean.class);
+
+    private TracingAttachments() {}
+}

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/UndertowTracing.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/UndertowTracing.java
@@ -1,0 +1,124 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tracing.undertow;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.palantir.tracing.DetachedSpan;
+import com.palantir.tracing.InternalTracers;
+import com.palantir.tracing.Observability;
+import com.palantir.tracing.Tracers;
+import com.palantir.tracing.api.SpanType;
+import com.palantir.tracing.api.TraceHttpHeaders;
+import io.undertow.server.ExchangeCompletionListener;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.AttachmentKey;
+import io.undertow.util.HeaderMap;
+import io.undertow.util.HttpString;
+import java.util.Optional;
+
+/**
+ * Internal utility functionality shared between {@link TracedOperationHandler} and {@link TracedRequestHandler}.
+ * Intentionally package private.
+ */
+final class UndertowTracing {
+
+    // Tracing header definitions
+    private static final HttpString TRACE_ID = HttpString.tryFromString(TraceHttpHeaders.TRACE_ID);
+    private static final HttpString SPAN_ID = HttpString.tryFromString(TraceHttpHeaders.SPAN_ID);
+    private static final HttpString IS_SAMPLED = HttpString.tryFromString(TraceHttpHeaders.IS_SAMPLED);
+
+    // Consider moving this to TracingAttachments and making it public. For now it's well encapsulated
+    // here because we expect the two handler implementations to be sufficient.
+    /** Detached span object representing the entire request including asynchronous components. */
+    @VisibleForTesting
+    static final AttachmentKey<DetachedSpan> REQUEST_SPAN = AttachmentKey.create(DetachedSpan.class);
+
+    private static final String OPERATION_NAME = "Undertow Request";
+
+    /**
+     * Apply detached tracing state to the provided {@link HttpServerExchange request}.
+     */
+    static DetachedSpan getOrInitializeRequestTrace(HttpServerExchange exchange) {
+        DetachedSpan detachedSpan = exchange.getAttachment(REQUEST_SPAN);
+        if (detachedSpan == null) {
+            return initializeRequestTrace(exchange);
+        }
+        return detachedSpan;
+    }
+
+    private static DetachedSpan initializeRequestTrace(HttpServerExchange exchange) {
+        HeaderMap requestHeaders = exchange.getRequestHeaders();
+        String maybeTraceId = requestHeaders.getFirst(TRACE_ID);
+        boolean newTraceId = maybeTraceId == null;
+        String traceId = newTraceId ? Tracers.randomId() : maybeTraceId;
+        DetachedSpan detachedSpan = detachedSpan(newTraceId, traceId, requestHeaders);
+        setExchangeState(exchange, detachedSpan, traceId);
+        return detachedSpan;
+    }
+
+    private static void setExchangeState(HttpServerExchange exchange, DetachedSpan detachedSpan, String traceId) {
+        // Populate response before proceeding since later operations might commit the response.
+        exchange.getResponseHeaders().put(TRACE_ID, traceId);
+        exchange.putAttachment(TracingAttachments.IS_SAMPLED, InternalTracers.isSampled(detachedSpan));
+        exchange.putAttachment(REQUEST_SPAN, detachedSpan);
+        exchange.addExchangeCompleteListener(DetachedTraceCompletionListener.INSTANCE);
+    }
+
+    private static DetachedSpan detachedSpan(
+            boolean newTrace,
+            String traceId,
+            HeaderMap requestHeaders) {
+        return DetachedSpan.start(
+                getObservabilityFromHeader(requestHeaders),
+                traceId,
+                newTrace ? Optional.empty() : Optional.ofNullable(requestHeaders.getFirst(SPAN_ID)),
+                OPERATION_NAME,
+                SpanType.SERVER_INCOMING);
+    }
+
+    private enum DetachedTraceCompletionListener implements ExchangeCompletionListener {
+        INSTANCE;
+
+        @Override
+        public void exchangeEvent(HttpServerExchange exchange, NextListener nextListener) {
+            try {
+                DetachedSpan detachedSpan = exchange.getAttachment(REQUEST_SPAN);
+                if (detachedSpan != null) {
+                    detachedSpan.complete();
+                }
+            } finally {
+                nextListener.proceed();
+            }
+        }
+    }
+
+    /**
+     * Force sample iff the context contains a "1" X-B3-Sampled header, force not sample if the header contains another
+     * non-empty value, or undecided if there is no such header or the header is empty.
+     */
+    private static Observability getObservabilityFromHeader(HeaderMap headers) {
+        String header = headers.getFirst(IS_SAMPLED);
+        if (Strings.isNullOrEmpty(header)) {
+            return Observability.UNDECIDED;
+        } else {
+            return "1".equals(header) ? Observability.SAMPLE : Observability.DO_NOT_SAMPLE;
+        }
+    }
+
+    private UndertowTracing() {}
+}

--- a/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedOperationHandlerTest.java
+++ b/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedOperationHandlerTest.java
@@ -18,11 +18,14 @@ package com.palantir.tracing.undertow;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.palantir.tracing.TraceMetadata;
 import com.palantir.tracing.TraceSampler;
 import com.palantir.tracing.Tracer;
 import com.palantir.tracing.Tracers;
@@ -33,6 +36,7 @@ import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.HttpString;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Before;
@@ -42,6 +46,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 import org.slf4j.MDC;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -113,10 +118,35 @@ public class TracedOperationHandlerTest {
         setRequestSpanId(parentSpanId);
 
         handler.handleRequest(exchange);
-        verify(observer).consume(spanCaptor.capture());
-        Span span = spanCaptor.getValue();
-        assertThat(span.getParentSpanId()).contains(parentSpanId);
+        // Since we're not running a full request, the completion handler cannot execute normally.
+        exchange.getAttachment(UndertowTracing.REQUEST_SPAN).complete();
+        verify(observer, times(2)).consume(spanCaptor.capture());
+        List<Span> spans = spanCaptor.getAllValues();
+        assertThat(spans).hasSize(2);
+        Span span = spans.get(1);
+        assertThat(spans.get(0).getParentSpanId()).hasValue(span.getSpanId());
+        assertThat(span.getParentSpanId()).hasValue(parentSpanId);
         assertThat(span.getSpanId()).isNotEqualTo(parentSpanId);
+    }
+
+    @Test
+    public void whenParentSpanIsGiven_usesParentSpan_unsampled() throws Exception {
+        when(traceSampler.sample()).thenReturn(false);
+        setRequestTraceId(traceId);
+        String parentSpanId = Tracers.randomId();
+        setRequestSpanId(parentSpanId);
+
+        AtomicReference<String> capturedParentSpanId = new AtomicReference<>();
+        doAnswer((Answer<Void>) invocation -> {
+            Tracer.maybeGetTraceMetadata()
+                    .flatMap(TraceMetadata::getOriginatingSpanId)
+                    .ifPresent(capturedParentSpanId::set);
+            return null;
+        }).when(delegate).handleRequest(any());
+
+        handler.handleRequest(exchange);
+
+        assertThat(capturedParentSpanId).hasValue(parentSpanId);
     }
 
     @Test
@@ -138,7 +168,7 @@ public class TracedOperationHandlerTest {
         exchange.getRequestHeaders().put(HttpString.tryFromString(TraceHttpHeaders.IS_SAMPLED), "1");
         handler.handleRequest(exchange);
 
-        assertThat(exchange.getAttachment(TracedOperationHandler.IS_SAMPLED_ATTACHMENT))
+        assertThat(exchange.getAttachment(TracingAttachments.IS_SAMPLED))
                 .isTrue();
     }
 
@@ -147,7 +177,7 @@ public class TracedOperationHandlerTest {
         exchange.getRequestHeaders().put(HttpString.tryFromString(TraceHttpHeaders.IS_SAMPLED), "0");
         handler.handleRequest(exchange);
 
-        assertThat(exchange.getAttachment(TracedOperationHandler.IS_SAMPLED_ATTACHMENT))
+        assertThat(exchange.getAttachment(TracingAttachments.IS_SAMPLED))
                 .isFalse();
     }
 

--- a/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedRequestHandlerTest.java
+++ b/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedRequestHandlerTest.java
@@ -1,0 +1,154 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tracing.undertow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.palantir.tracing.TraceSampler;
+import com.palantir.tracing.Tracer;
+import com.palantir.tracing.api.Span;
+import com.palantir.tracing.api.SpanObserver;
+import com.palantir.tracing.api.TraceHttpHeaders;
+import io.undertow.Undertow;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.handlers.ResponseCodeHandler;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TracedRequestHandlerTest {
+
+    private static final AtomicInteger portSelector = new AtomicInteger(4439);
+
+    private int port;
+    private Undertow server;
+
+    @Captor
+    private ArgumentCaptor<Span> spanCaptor;
+
+    @Mock
+    private SpanObserver observer;
+
+    @Mock
+    private TraceSampler traceSampler;
+
+    private CountDownLatch traceReportedLatch;
+
+    @Before
+    public void before() {
+        Tracer.subscribe("TracedRequestHandlerTest", observer);
+        Tracer.setSampler(traceSampler);
+
+        traceReportedLatch = new CountDownLatch(1);
+        port = portSelector.incrementAndGet();
+        HttpHandler nextHandler = new TracedRequestHandler(ResponseCodeHandler.HANDLE_200);
+        server = Undertow.builder()
+                .addHttpListener(port, null)
+                .setHandler(exchange -> {
+                    exchange.addExchangeCompleteListener((_exc, nextListener) -> {
+                        traceReportedLatch.countDown();
+                        nextListener.proceed();
+                    });
+                    nextHandler.handleRequest(exchange);
+                })
+                .build();
+        server.start();
+    }
+
+    @After
+    public void after() {
+        Tracer.unsubscribe("TracedRequestHandlerTest");
+        server.stop();
+    }
+
+    private HttpURLConnection connection() throws IOException {
+        return (HttpURLConnection) new URL("http://localhost:" + port).openConnection();
+    }
+
+    @Test
+    public void testRequestTracing_sampled() throws Exception {
+        HttpURLConnection con = connection();
+        con.setRequestProperty(TraceHttpHeaders.IS_SAMPLED, "1");
+        con.setRequestProperty(TraceHttpHeaders.TRACE_ID, "1234");
+        assertThat(con.getResponseCode()).isEqualTo(200);
+        assertThat(con.getHeaderField(TraceHttpHeaders.TRACE_ID)).isEqualTo("1234");
+        assertThat(traceReportedLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        verifyNoMoreInteractions(traceSampler);
+        verify(observer).consume(spanCaptor.capture());
+        Span span = spanCaptor.getValue();
+        assertThat(span.getOperation()).isEqualTo("Undertow Request");
+        assertThat(span.getTraceId()).isEqualTo("1234");
+    }
+
+    @Test
+    public void testRequestTracing_unsampled() throws Exception {
+        HttpURLConnection con = connection();
+        con.setRequestProperty(TraceHttpHeaders.IS_SAMPLED, "0");
+        con.setRequestProperty(TraceHttpHeaders.TRACE_ID, "1234");
+        assertThat(con.getResponseCode()).isEqualTo(200);
+        assertThat(con.getHeaderField(TraceHttpHeaders.TRACE_ID)).isEqualTo("1234");
+        assertThat(traceReportedLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        verifyNoMoreInteractions(traceSampler);
+        verifyNoMoreInteractions(observer);
+    }
+
+    @Test
+    public void testRequestTracing_sampledWithoutTraceId() throws Exception {
+        HttpURLConnection con = connection();
+        con.setRequestProperty(TraceHttpHeaders.IS_SAMPLED, "1");
+        assertThat(con.getResponseCode()).isEqualTo(200);
+        String reportedTraceId = con.getHeaderField(TraceHttpHeaders.TRACE_ID);
+        assertThat(traceReportedLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(reportedTraceId).isNotEmpty();
+        verifyNoMoreInteractions(traceSampler);
+        verify(observer).consume(spanCaptor.capture());
+        Span span = spanCaptor.getValue();
+        assertThat(span.getOperation()).isEqualTo("Undertow Request");
+        assertThat(span.getTraceId()).isEqualTo(reportedTraceId);
+    }
+
+    @Test
+    public void testRequestTracing_noTracingInformation() throws Exception {
+        HttpURLConnection con = connection();
+        when(traceSampler.sample()).thenReturn(true);
+        assertThat(con.getResponseCode()).isEqualTo(200);
+        String reportedTraceId = con.getHeaderField(TraceHttpHeaders.TRACE_ID);
+        assertThat(traceReportedLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(reportedTraceId).isNotEmpty();
+        verify(traceSampler).sample();
+        verifyNoMoreInteractions(traceSampler);
+        verify(observer).consume(spanCaptor.capture());
+        Span span = spanCaptor.getValue();
+        assertThat(span.getOperation()).isEqualTo("Undertow Request");
+        assertThat(span.getTraceId()).isEqualTo(reportedTraceId);
+    }
+}

--- a/tracing/src/main/java/com/palantir/tracing/DetachedSpan.java
+++ b/tracing/src/main/java/com/palantir/tracing/DetachedSpan.java
@@ -18,6 +18,7 @@ package com.palantir.tracing;
 
 import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.tracing.api.SpanType;
+import java.util.Optional;
 import javax.annotation.CheckReturnValue;
 
 /** Span which is not bound to thread state, and can be completed on any other thread. */
@@ -46,6 +47,21 @@ public interface DetachedSpan {
     @CheckReturnValue
     static DetachedSpan start(String operation, SpanType type) {
         return Tracer.detachInternal(operation, type);
+    }
+
+    /**
+     * Marks the beginning of a span, which you can {@link #complete} on any other thread.
+     *
+     * @see DetachedSpan#start(String)
+     */
+    @CheckReturnValue
+    static DetachedSpan start(
+            Observability observability,
+            String traceId,
+            Optional<String> parentSpanId,
+            String operation,
+            SpanType type) {
+        return Tracer.detachInternal(observability, traceId, parentSpanId, operation, type);
     }
 
     /**

--- a/tracing/src/main/java/com/palantir/tracing/InternalTracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/InternalTracers.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tracing;
+
+/**
+ * Internal utilities meant for consumption only inside of the tracing codebase.
+ *
+ * Note: while this is internal, backwards compatibility should be preserved
+ * for a couple releases to prevent breaking libraries which resolve mis-matched
+ * tracing dependency versions.
+ */
+public final class InternalTracers {
+
+    /** Returns true if the provided detachedSpan is sampled. */
+    public static boolean isSampled(DetachedSpan detachedSpan) {
+        return Tracer.isSampled(detachedSpan);
+    }
+
+    private InternalTracers() {}
+}


### PR DESCRIPTION
Implement TracedRequestHandler which can be applied prior to blocking
operations in order to capture more of the request lifecycle.
The existing handler attaches the detached span created by the
request handler in order to provide more specific timing information
describing the blocking portion of the request.

For backwards compatibility, the existing TracedOperationHandler
can still be used without the TracedRequestHandler, however the
detached request span will be started when the TracedOperationHandler
is first executed.

## Before this PR
We did not support tracing the full request lifecycle across synchronous and asynchronous operations.

## After this PR
==COMMIT_MSG==
Provide Tracing support for the full Undertow request lifecycle
==COMMIT_MSG==

