### PR TITLE
publish test utils

### DIFF
--- a/changelog/@unreleased/pr-442.v2.yml
+++ b/changelog/@unreleased/pr-442.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Publish `tracing-test-utils`
+  links:
+  - https://github.com/palantir/tracing-java/pull/442

--- a/tracing-test-utils/build.gradle
+++ b/tracing-test-utils/build.gradle
@@ -1,5 +1,4 @@
-// temporarily disabling publishing on this so we can iterate further on the API before we commit to something
-// apply from: "${rootDir}/gradle/publish-jar.gradle"
+ apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 versionsLock {
     testProject()


### PR DESCRIPTION
## Before this PR
We did not publish the testing library

## After this PR
==COMMIT_MSG==
Publish `tracing-test-utils`
==COMMIT_MSG==

I hope to leverage the library to improve dialogue's tracing

## Possible downsides?
Additional API surface area

