### PR TITLE
Tracing uniquely identifies requests

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,0 +1,6 @@
+acceptedBreaks:
+  "4.5.2":
+    com.palantir.tracing:tracing:
+    - code: "java.method.addedToInterface"
+      new: "method java.util.Optional<java.lang.String> com.palantir.tracing.TraceMetadata::getRequestId()"
+      justification: "immutables are not for extension"

--- a/changelog/@unreleased/pr-574.v2.yml
+++ b/changelog/@unreleased/pr-574.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Tracing uniquely identifies requests with request metadata and a `_requestId`
+    MDC property.
+  links:
+  - https://github.com/palantir/tracing-java/pull/574

--- a/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
+++ b/tracing-jersey/src/main/java/com/palantir/tracing/jersey/TraceEnrichingFilter.java
@@ -18,6 +18,7 @@ package com.palantir.tracing.jersey;
 
 import com.google.common.base.Strings;
 import com.palantir.tracing.Observability;
+import com.palantir.tracing.TraceMetadata;
 import com.palantir.tracing.Tracer;
 import com.palantir.tracing.Tracers;
 import com.palantir.tracing.api.Span;
@@ -86,7 +87,9 @@ public final class TraceEnrichingFilter implements ContainerRequestFilter, Conta
         // Give asynchronous downstream handlers access to the trace id
         requestContext.setProperty(TRACE_ID_PROPERTY_NAME, Tracer.getTraceId());
         requestContext.setProperty(SAMPLED_PROPERTY_NAME, Tracer.isTraceObservable());
-        Tracer.getRequestId().ifPresent(requestId -> requestContext.setProperty(REQUEST_ID_PROPERTY_NAME, requestId));
+        Tracer.maybeGetTraceMetadata()
+                .flatMap(TraceMetadata::getRequestId)
+                .ifPresent(requestId -> requestContext.setProperty(REQUEST_ID_PROPERTY_NAME, requestId));
     }
 
     // Handles outgoing response

--- a/tracing-jersey/src/test/java/com/palantir/tracing/jersey/TraceEnrichingFilterTest.java
+++ b/tracing-jersey/src/test/java/com/palantir/tracing/jersey/TraceEnrichingFilterTest.java
@@ -225,6 +225,7 @@ public final class TraceEnrichingFilterTest {
         verify(request).setProperty(TraceEnrichingFilter.TRACE_ID_PROPERTY_NAME, "traceId");
         // Note: this will be set to a random value; we want to check whether the value is being set
         verify(request).setProperty(eq(TraceEnrichingFilter.SAMPLED_PROPERTY_NAME), anyBoolean());
+        verify(request).setProperty(eq(TraceEnrichingFilter.REQUEST_ID_PROPERTY_NAME), anyString());
     }
 
     @Test
@@ -240,6 +241,7 @@ public final class TraceEnrichingFilterTest {
         TraceEnrichingFilter.INSTANCE.filter(request);
         assertThat(MDC.get(Tracers.TRACE_ID_KEY)).hasSize(16);
         verify(request).setProperty(eq(TraceEnrichingFilter.TRACE_ID_PROPERTY_NAME), anyString());
+        verify(request).setProperty(eq(TraceEnrichingFilter.REQUEST_ID_PROPERTY_NAME), anyString());
     }
 
     public static class TracingTestServer extends Application<Configuration> {

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracingAttachments.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracingAttachments.java
@@ -24,5 +24,8 @@ public final class TracingAttachments {
     /** Attachment to check whether the current request is being traced. */
     public static final AttachmentKey<Boolean> IS_SAMPLED = AttachmentKey.create(Boolean.class);
 
+    /** Attachment providing the request identifier. */
+    public static final AttachmentKey<String> REQUEST_ID = AttachmentKey.create(String.class);
+
     private TracingAttachments() {}
 }

--- a/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
@@ -65,6 +65,9 @@ public final class DeferredTracer implements Serializable {
     @Nullable
     private final String parentSpanId;
 
+    @Nullable
+    private final transient String requestId;
+
     /**
      * Deprecated.
      *
@@ -90,11 +93,13 @@ public final class DeferredTracer implements Serializable {
         if (maybeTrace.isPresent()) {
             Trace trace = maybeTrace.get();
             this.traceId = trace.getTraceId();
+            this.requestId = trace.getRequestId().orElse(null);
             this.isObservable = trace.isObservable();
             this.parentSpanId = trace.top().map(OpenSpan::getSpanId).orElse(null);
             this.operation = operation;
         } else {
             this.traceId = null;
+            this.requestId = null;
             this.isObservable = false;
             this.parentSpanId = null;
             this.operation = null;
@@ -117,7 +122,7 @@ public final class DeferredTracer implements Serializable {
 
         Optional<Trace> originalTrace = Tracer.copyTrace();
 
-        Tracer.setTrace(Trace.of(isObservable, traceId));
+        Tracer.setTrace(Trace.of(isObservable, traceId, Optional.ofNullable(requestId)));
         if (parentSpanId != null) {
             Tracer.fastStartSpan(operation, parentSpanId, SpanType.LOCAL);
         } else {

--- a/tracing/src/main/java/com/palantir/tracing/DetachedSpan.java
+++ b/tracing/src/main/java/com/palantir/tracing/DetachedSpan.java
@@ -65,22 +65,6 @@ public interface DetachedSpan {
     }
 
     /**
-     * Marks the beginning of a span, which you can {@link #complete} on any other thread.
-     *
-     * @see DetachedSpan#start(String)
-     */
-    @CheckReturnValue
-    static DetachedSpan start(
-            Observability observability,
-            String traceId,
-            Optional<String> requestId,
-            Optional<String> parentSpanId,
-            String operation,
-            SpanType type) {
-        return Tracer.detachInternal(observability, traceId, requestId, parentSpanId, operation, type);
-    }
-
-    /**
      * Equivalent to {@link Tracer#startSpan(String, SpanType)}, but using this {@link DetachedSpan} as the parent
      * instead of thread state.
      */

--- a/tracing/src/main/java/com/palantir/tracing/DetachedSpan.java
+++ b/tracing/src/main/java/com/palantir/tracing/DetachedSpan.java
@@ -65,6 +65,22 @@ public interface DetachedSpan {
     }
 
     /**
+     * Marks the beginning of a span, which you can {@link #complete} on any other thread.
+     *
+     * @see DetachedSpan#start(String)
+     */
+    @CheckReturnValue
+    static DetachedSpan start(
+            Observability observability,
+            String traceId,
+            Optional<String> requestId,
+            Optional<String> parentSpanId,
+            String operation,
+            SpanType type) {
+        return Tracer.detachInternal(observability, traceId, requestId, parentSpanId, operation, type);
+    }
+
+    /**
      * Equivalent to {@link Tracer#startSpan(String, SpanType)}, but using this {@link DetachedSpan} as the parent
      * instead of thread state.
      */

--- a/tracing/src/main/java/com/palantir/tracing/InternalTracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/InternalTracers.java
@@ -16,6 +16,8 @@
 
 package com.palantir.tracing;
 
+import java.util.Optional;
+
 /**
  * Internal utilities meant for consumption only inside of the tracing codebase.
  *
@@ -27,6 +29,11 @@ public final class InternalTracers {
     /** Returns true if the provided detachedSpan is sampled. */
     public static boolean isSampled(DetachedSpan detachedSpan) {
         return Tracer.isSampled(detachedSpan);
+    }
+
+    /** Returns true if the provided detachedSpan is sampled. */
+    public static Optional<String> getRequestId(DetachedSpan detachedSpan) {
+        return Tracer.getRequestId(detachedSpan);
     }
 
     private InternalTracers() {}

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -17,6 +17,7 @@
 package com.palantir.tracing;
 
 import static com.palantir.logsafe.Preconditions.checkArgument;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 import static com.palantir.logsafe.Preconditions.checkState;
 
 import com.google.common.base.Strings;
@@ -45,9 +46,12 @@ public abstract class Trace {
 
     private final String traceId;
 
-    private Trace(String traceId) {
+    private final Optional<String> requestId;
+
+    private Trace(String traceId, Optional<String> requestId) {
         checkArgument(!Strings.isNullOrEmpty(traceId), "traceId must be non-empty");
         this.traceId = traceId;
+        this.requestId = checkNotNull(requestId, "requestId");
     }
 
     /**
@@ -125,26 +129,31 @@ public abstract class Trace {
         return traceId;
     }
 
+    /** The request identifier of this trace. */
+    final Optional<String> getRequestId() {
+        return requestId;
+    }
+
     abstract Optional<String> getOriginatingSpanId();
 
     /** Returns a copy of this Trace which can be independently mutated. */
     abstract Trace deepCopy();
 
-    static Trace of(boolean isObservable, String traceId) {
-        return isObservable ? new Sampled(traceId) : new Unsampled(traceId);
+    static Trace of(boolean isObservable, String traceId, Optional<String> requestId) {
+        return isObservable ? new Sampled(traceId, requestId) : new Unsampled(traceId, requestId);
     }
 
     private static final class Sampled extends Trace {
 
         private final Deque<OpenSpan> stack;
 
-        private Sampled(ArrayDeque<OpenSpan> stack, String traceId) {
-            super(traceId);
+        private Sampled(ArrayDeque<OpenSpan> stack, String traceId, Optional<String> requestId) {
+            super(traceId, requestId);
             this.stack = stack;
         }
 
-        private Sampled(String traceId) {
-            this(new ArrayDeque<>(), traceId);
+        private Sampled(String traceId, Optional<String> requestId) {
+            this(new ArrayDeque<>(), traceId, requestId);
         }
 
         @Override
@@ -194,7 +203,7 @@ public abstract class Trace {
 
         @Override
         Trace deepCopy() {
-            return new Sampled(new ArrayDeque<>(stack), getTraceId());
+            return new Sampled(new ArrayDeque<>(stack), getTraceId(), getRequestId());
         }
 
         @Override
@@ -212,14 +221,14 @@ public abstract class Trace {
 
         private Optional<String> originatingSpanId = Optional.empty();
 
-        private Unsampled(int numberOfSpans, String traceId) {
-            super(traceId);
+        private Unsampled(int numberOfSpans, String traceId, Optional<String> requestId) {
+            super(traceId, requestId);
             this.numberOfSpans = numberOfSpans;
             validateNumberOfSpans();
         }
 
-        private Unsampled(String traceId) {
-            this(0, traceId);
+        private Unsampled(String traceId, Optional<String> requestId) {
+            this(0, traceId, requestId);
         }
 
         @Override
@@ -279,7 +288,7 @@ public abstract class Trace {
 
         @Override
         Trace deepCopy() {
-            return new Unsampled(numberOfSpans, getTraceId());
+            return new Unsampled(numberOfSpans, getTraceId(), getRequestId());
         }
 
         /** Internal validation, this should never fail because {@link #pop()} only decrements positive values. */
@@ -292,7 +301,8 @@ public abstract class Trace {
 
         @Override
         public String toString() {
-            return "Trace{numberOfSpans=" + numberOfSpans + ", isObservable=false, traceId='" + getTraceId() + "'}";
+            return "Trace{numberOfSpans=" + numberOfSpans + ", isObservable=false, traceId='" + getTraceId()
+                    + "', requestId='" + getRequestId().orElse(null) + "'}";
         }
     }
 }

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -129,7 +129,13 @@ public abstract class Trace {
         return traceId;
     }
 
-    /** The request identifier of this trace. */
+    /**
+     * The request identifier of this trace.
+     *
+     * The request identifier is an implementation detail of this tracing library. A new identifier is generated
+     * each time a new trace is created with a SERVER_INCOMING root span. This is a convenience in order to
+     * distinguish between requests with the same traceId.
+     */
     final Optional<String> getRequestId() {
         return requestId;
     }

--- a/tracing/src/main/java/com/palantir/tracing/TraceMetadata.java
+++ b/tracing/src/main/java/com/palantir/tracing/TraceMetadata.java
@@ -27,6 +27,12 @@ public interface TraceMetadata {
     /** Corresponds to {@link com.palantir.tracing.api.TraceHttpHeaders#TRACE_ID}. */
     String getTraceId();
 
+    /**
+     * Returns the unique request identifier for this thread's trace.
+     * Corresponds to {@link com.palantir.tracing.Tracers#REQUEST_ID_KEY}.
+     */
+    Optional<String> getRequestId();
+
     /** Corresponds to {@link com.palantir.tracing.api.TraceHttpHeaders#SPAN_ID}. */
     String getSpanId();
 

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -16,10 +16,6 @@
 
 package com.palantir.tracing;
 
-import static com.palantir.logsafe.Preconditions.checkArgument;
-import static com.palantir.logsafe.Preconditions.checkNotNull;
-import static com.palantir.logsafe.Preconditions.checkState;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.errorprone.annotations.CheckReturnValue;
@@ -34,16 +30,21 @@ import com.palantir.tracing.api.OpenSpan;
 import com.palantir.tracing.api.Span;
 import com.palantir.tracing.api.SpanObserver;
 import com.palantir.tracing.api.SpanType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
+
+import static com.palantir.logsafe.Preconditions.checkArgument;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkState;
 
 /**
  * The singleton entry point for handling Zipkin-style traces and spans. Provides functionality for starting and
@@ -117,6 +118,7 @@ public final class Tracer {
                     .parentSpanId(openSpan.getParentSpanId())
                     .originatingSpanId(trace.getOriginatingSpanId())
                     .traceId(trace.getTraceId())
+                    .requestId(trace.getRequestId())
                     .build());
         } else {
             return Optional.of(TraceMetadata.builder()
@@ -124,6 +126,7 @@ public final class Tracer {
                     .parentSpanId(Optional.empty())
                     .originatingSpanId(trace.getOriginatingSpanId())
                     .traceId(trace.getTraceId())
+                    .requestId(trace.getRequestId())
                     .build());
         }
     }

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -16,6 +16,10 @@
 
 package com.palantir.tracing;
 
+import static com.palantir.logsafe.Preconditions.checkArgument;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkState;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.errorprone.annotations.CheckReturnValue;
@@ -30,21 +34,16 @@ import com.palantir.tracing.api.OpenSpan;
 import com.palantir.tracing.api.Span;
 import com.palantir.tracing.api.SpanObserver;
 import com.palantir.tracing.api.SpanType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
-
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-
-import static com.palantir.logsafe.Preconditions.checkArgument;
-import static com.palantir.logsafe.Preconditions.checkNotNull;
-import static com.palantir.logsafe.Preconditions.checkState;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 /**
  * The singleton entry point for handling Zipkin-style traces and spans. Provides functionality for starting and

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -298,11 +298,6 @@ public final class Tracer {
         throw new SafeIllegalStateException("Unknown span type", SafeArg.of("detachedSpan", detachedSpan));
     }
 
-    /** Returns the unique request identifier for this thread's trace. */
-    public static Optional<String> getRequestId() {
-        return checkNotNull(currentTrace.get(), "There is no trace").getRequestId();
-    }
-
     static boolean isSampled(DetachedSpan detachedSpan) {
         return detachedSpan instanceof SampledDetachedSpan;
     }

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -28,6 +28,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.tracing.api.OpenSpan;
 import com.palantir.tracing.api.Span;
@@ -69,10 +70,10 @@ public final class Tracer {
     private static volatile TraceSampler sampler = RandomSampler.create(0.01f);
 
     /** Creates a new trace, but does not set it as the current trace. */
-    private static Trace createTrace(Observability observability, String traceId) {
+    private static Trace createTrace(Observability observability, String traceId, Optional<String> requestId) {
         checkArgument(!Strings.isNullOrEmpty(traceId), "traceId must be non-empty");
         boolean observable = shouldObserve(observability);
-        return Trace.of(observable, traceId);
+        return Trace.of(observable, traceId, requestId);
     }
 
     private static boolean shouldObserve(Observability observability) {
@@ -138,12 +139,42 @@ public final class Tracer {
                 .map(observable -> observable ? Observability.SAMPLE : Observability.DO_NOT_SAMPLE)
                 .orElse(Observability.UNDECIDED);
 
-        setTrace(createTrace(observability, traceId));
+        setTrace(createTrace(observability, traceId, Optional.empty()));
     }
 
-    /** Initializes the current thread's trace, erasing any previously accrued open spans. */
+    /**
+     * Initializes the current thread's trace, erasing any previously accrued open spans.
+     *
+     * @deprecated Use {@link #initTraceWithSpan(Observability, String, String, SpanType)}
+     */
+    @Deprecated
     public static void initTrace(Observability observability, String traceId) {
-        setTrace(createTrace(observability, traceId));
+        setTrace(createTrace(observability, traceId, Optional.empty()));
+    }
+
+    /**
+     * Initializes the current thread's trace with a root span, erasing any previously accrued open spans.
+     * The root span must eventually be completed using {@link #fastCompleteSpan()} or {@link #completeSpan()}.
+     */
+    public static void initTraceWithSpan(
+            Observability observability, String traceId, String operation, String parentSpanId, SpanType type) {
+        setTrace(createTrace(
+                observability,
+                traceId,
+                type == SpanType.SERVER_INCOMING ? Optional.of(Tracers.randomId()) : Optional.empty()));
+        fastStartSpan(operation, parentSpanId, type);
+    }
+
+    /**
+     * Initializes the current thread's trace with a root span, erasing any previously accrued open spans.
+     * The root span must eventually be completed using {@link #fastCompleteSpan()} or {@link #completeSpan()}.
+     */
+    public static void initTraceWithSpan(Observability observability, String traceId, String operation, SpanType type) {
+        setTrace(createTrace(
+                observability,
+                traceId,
+                type == SpanType.SERVER_INCOMING ? Optional.of(Tracers.randomId()) : Optional.empty()));
+        fastStartSpan(operation, type);
     }
 
     /**
@@ -198,9 +229,10 @@ public final class Tracer {
         String traceId = maybeCurrentTrace != null ? maybeCurrentTrace.getTraceId() : Tracers.randomId();
         boolean sampled = maybeCurrentTrace != null ? maybeCurrentTrace.isObservable() : sampler.sample();
         Optional<String> parentSpan = getParentSpanId(maybeCurrentTrace);
+        Optional<String> requestId = getRequestId(maybeCurrentTrace, type);
         return sampled
-                ? new SampledDetachedSpan(operation, type, traceId, parentSpan)
-                : new UnsampledDetachedSpan(traceId, parentSpan);
+                ? new SampledDetachedSpan(operation, type, traceId, requestId, parentSpan)
+                : new UnsampledDetachedSpan(traceId, requestId, parentSpan);
     }
 
     /**
@@ -213,11 +245,27 @@ public final class Tracer {
             Optional<String> parentSpanId,
             String operation,
             SpanType type) {
+        Optional<String> requestId =
+                type == SpanType.SERVER_INCOMING ? Optional.of(Tracers.randomId()) : Optional.empty();
+        return detachInternal(observability, traceId, requestId, parentSpanId, operation, type);
+    }
+
+    /**
+     * Like {@link #startSpan(String, SpanType)}, but does not set or modify tracing thread state. This is an internal
+     * utility that should not be called directly outside of {@link DetachedSpan}.
+     */
+    static DetachedSpan detachInternal(
+            Observability observability,
+            String traceId,
+            Optional<String> requestId,
+            Optional<String> parentSpanId,
+            String operation,
+            SpanType type) {
         // The current trace has no impact on this function, a new trace is spawned and existing thread state
         // is not modified.
         return shouldObserve(observability)
-                ? new SampledDetachedSpan(operation, type, traceId, parentSpanId)
-                : new UnsampledDetachedSpan(traceId, parentSpanId);
+                ? new SampledDetachedSpan(operation, type, traceId, requestId, parentSpanId)
+                : new UnsampledDetachedSpan(traceId, requestId, parentSpanId);
     }
 
     private static Optional<String> getParentSpanId(@Nullable Trace trace) {
@@ -230,6 +278,31 @@ public final class Tracer {
         return Optional.empty();
     }
 
+    private static Optional<String> getRequestId(@Nullable Trace maybeCurrentTrace, SpanType newSpanType) {
+        if (maybeCurrentTrace != null) {
+            return maybeCurrentTrace.getRequestId();
+        }
+        if (newSpanType == SpanType.SERVER_INCOMING) {
+            return Optional.of(Tracers.randomId());
+        }
+        return Optional.empty();
+    }
+
+    static Optional<String> getRequestId(DetachedSpan detachedSpan) {
+        if (detachedSpan instanceof SampledDetachedSpan) {
+            return ((SampledDetachedSpan) detachedSpan).requestId;
+        }
+        if (detachedSpan instanceof UnsampledDetachedSpan) {
+            return ((UnsampledDetachedSpan) detachedSpan).requestId;
+        }
+        throw new SafeIllegalStateException("Unknown span type", SafeArg.of("detachedSpan", detachedSpan));
+    }
+
+    /** Returns the unique request identifier for this thread's trace. */
+    public static Optional<String> getRequestId() {
+        return checkNotNull(currentTrace.get(), "There is no trace").getRequestId();
+    }
+
     static boolean isSampled(DetachedSpan detachedSpan) {
         return detachedSpan instanceof SampledDetachedSpan;
     }
@@ -238,10 +311,17 @@ public final class Tracer {
 
         private final AtomicBoolean completed = new AtomicBoolean();
         private final String traceId;
+        private final Optional<String> requestId;
         private final OpenSpan openSpan;
 
-        SampledDetachedSpan(String operation, SpanType type, String traceId, Optional<String> parentSpanId) {
+        SampledDetachedSpan(
+                String operation,
+                SpanType type,
+                String traceId,
+                Optional<String> requestId,
+                Optional<String> parentSpanId) {
             this.traceId = traceId;
+            this.requestId = requestId;
             this.openSpan = OpenSpan.builder()
                     .parentSpanId(parentSpanId)
                     .spanId(Tracers.randomId())
@@ -255,7 +335,7 @@ public final class Tracer {
         public CloseableSpan childSpan(String operationName, SpanType type) {
             warnIfCompleted("startSpanOnCurrentThread");
             Trace maybeCurrentTrace = currentTrace.get();
-            setTrace(Trace.of(true, traceId));
+            setTrace(Trace.of(true, traceId, requestId));
             Tracer.fastStartSpan(operationName, openSpan.getSpanId(), type);
             return TraceRestoringCloseableSpan.of(maybeCurrentTrace);
         }
@@ -263,7 +343,7 @@ public final class Tracer {
         @Override
         public DetachedSpan childDetachedSpan(String operation, SpanType type) {
             warnIfCompleted("startDetachedSpan");
-            return new SampledDetachedSpan(operation, type, traceId, Optional.of(openSpan.getSpanId()));
+            return new SampledDetachedSpan(operation, type, traceId, requestId, Optional.of(openSpan.getSpanId()));
         }
 
         @Override
@@ -279,6 +359,9 @@ public final class Tracer {
                     + completed
                     + ", traceId='"
                     + traceId
+                    + '\''
+                    + ", requestId='"
+                    + requestId.orElse(null)
                     + '\''
                     + ", openSpan="
                     + openSpan
@@ -298,17 +381,19 @@ public final class Tracer {
     private static final class UnsampledDetachedSpan implements DetachedSpan {
 
         private final String traceId;
+        private final Optional<String> requestId;
         private final Optional<String> parentSpanId;
 
-        UnsampledDetachedSpan(String traceId, Optional<String> parentSpanId) {
+        UnsampledDetachedSpan(String traceId, Optional<String> requestId, Optional<String> parentSpanId) {
             this.traceId = traceId;
+            this.requestId = requestId;
             this.parentSpanId = parentSpanId;
         }
 
         @Override
         public CloseableSpan childSpan(String operationName, SpanType type) {
             Trace maybeCurrentTrace = currentTrace.get();
-            setTrace(Trace.of(false, traceId));
+            setTrace(Trace.of(false, traceId, requestId));
             if (parentSpanId.isPresent()) {
                 Tracer.fastStartSpan(operationName, parentSpanId.get(), type);
             } else {
@@ -329,7 +414,7 @@ public final class Tracer {
 
         @Override
         public String toString() {
-            return "UnsampledDetachedSpan{traceId='" + traceId + "'}";
+            return "UnsampledDetachedSpan{traceId='" + traceId + "', requestId='" + requestId.orElse(null) + "'}";
         }
     }
 
@@ -555,6 +640,7 @@ public final class Tracer {
         // Give log appenders access to the trace id and whether the trace is being sampled
         MDC.put(Tracers.TRACE_ID_KEY, trace.getTraceId());
         setTraceSampledMdcIfObservable(trace.isObservable());
+        setTraceRequestId(trace.getRequestId());
     }
 
     private static void setTraceSampledMdcIfObservable(boolean observable) {
@@ -567,10 +653,19 @@ public final class Tracer {
         }
     }
 
+    private static void setTraceRequestId(Optional<String> requestId) {
+        if (requestId.isPresent()) {
+            MDC.put(Tracers.REQUEST_ID_KEY, requestId.get());
+        } else {
+            // Ensure MDC state is cleared when there is no request identifier
+            MDC.remove(Tracers.REQUEST_ID_KEY);
+        }
+    }
+
     private static Trace getOrCreateCurrentTrace() {
         Trace trace = currentTrace.get();
         if (trace == null) {
-            trace = createTrace(Observability.UNDECIDED, Tracers.randomId());
+            trace = createTrace(Observability.UNDECIDED, Tracers.randomId(), Optional.empty());
             setTrace(trace);
         }
         return trace;
@@ -581,5 +676,6 @@ public final class Tracer {
         currentTrace.remove();
         MDC.remove(Tracers.TRACE_ID_KEY);
         MDC.remove(Tracers.TRACE_SAMPLED_KEY);
+        MDC.remove(Tracers.REQUEST_ID_KEY);
     }
 }

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -133,7 +133,7 @@ public final class Tracer {
     /**
      * Deprecated.
      *
-     * @deprecated Use {@link #initTrace(Observability, String)}
+     * @deprecated Use {@link #initTraceWithSpan(Observability, String, String, SpanType)}
      */
     @Deprecated
     public static void initTrace(Optional<Boolean> isObservable, String traceId) {

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.tracing.api.SpanType;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -36,6 +37,9 @@ public final class Tracers {
      * field can take the values of "1" or "0", where "1" indicates the trace was sampled.
      */
     public static final String TRACE_SAMPLED_KEY = "_sampled";
+
+    /** The key under which tracing request ids are inserted into SLF4J {@link org.slf4j.MDC MDCs}. */
+    public static final String REQUEST_ID_KEY = "_requestId";
 
     private static final String DEFAULT_ROOT_SPAN_OPERATION = "root";
     private static final char[] HEX_DIGITS = {
@@ -332,8 +336,7 @@ public final class Tracers {
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
-                Tracer.initTrace(observability, Tracers.randomId());
-                Tracer.fastStartSpan(operation);
+                Tracer.initTraceWithSpan(observability, Tracers.randomId(), operation, SpanType.LOCAL);
                 return delegate.call();
             } finally {
                 Tracer.fastCompleteSpan();
@@ -368,8 +371,7 @@ public final class Tracers {
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
-                Tracer.initTrace(observability, Tracers.randomId());
-                Tracer.fastStartSpan(operation);
+                Tracer.initTraceWithSpan(observability, Tracers.randomId(), operation, SpanType.LOCAL);
                 delegate.run();
             } finally {
                 Tracer.fastCompleteSpan();
@@ -392,8 +394,7 @@ public final class Tracers {
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
-                Tracer.initTrace(observability, traceId);
-                Tracer.fastStartSpan(operation);
+                Tracer.initTraceWithSpan(observability, traceId, operation, SpanType.LOCAL);
                 return delegate.call();
             } finally {
                 Tracer.fastCompleteSpan();
@@ -430,8 +431,7 @@ public final class Tracers {
             Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
             try {
-                Tracer.initTrace(observability, traceId);
-                Tracer.fastStartSpan(operation);
+                Tracer.initTraceWithSpan(observability, traceId, operation, SpanType.LOCAL);
                 delegate.run();
             } finally {
                 Tracer.fastCompleteSpan();

--- a/tracing/src/test/java/com/palantir/tracing/AsyncSlf4jSpanObserverTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/AsyncSlf4jSpanObserverTest.java
@@ -102,8 +102,7 @@ public final class AsyncSlf4jSpanObserverTest {
         Tracer.subscribe(
                 TEST_OBSERVER,
                 AsyncSlf4jSpanObserver.of("serviceName", Inet4Address.getLoopbackAddress(), logger, executor));
-        Tracer.initTrace(Observability.SAMPLE, Tracers.randomId());
-        Tracer.fastStartSpan("operation");
+        Tracer.initTraceWithSpan(Observability.SAMPLE, Tracers.randomId(), "operation", SpanType.LOCAL);
         Span span = Tracer.completeSpan().get();
         verify(appender, never()).doAppend(any(ILoggingEvent.class)); // async logger only fires when executor runs
 
@@ -124,8 +123,7 @@ public final class AsyncSlf4jSpanObserverTest {
     public void testDefaultConstructorDeterminesIpAddress() throws Exception {
         DeterministicScheduler executor = new DeterministicScheduler();
         Tracer.subscribe(TEST_OBSERVER, AsyncSlf4jSpanObserver.of("serviceName", executor));
-        Tracer.initTrace(Observability.SAMPLE, Tracers.randomId());
-        Tracer.fastStartSpan("operation");
+        Tracer.initTraceWithSpan(Observability.SAMPLE, Tracers.randomId(), "operation", SpanType.LOCAL);
         Span span = Tracer.completeSpan().get();
 
         executor.runNextPendingCommand();

--- a/tracing/src/test/java/com/palantir/tracing/AsyncTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/AsyncTracerTest.java
@@ -18,8 +18,10 @@ package com.palantir.tracing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.tracing.api.SpanType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,7 +35,7 @@ public class AsyncTracerTest {
 
     @Test
     public void doesNotLeakEnqueueSpan() {
-        Tracer.initTrace(Observability.UNDECIDED, "defaultTraceId");
+        Tracer.setTrace(Trace.of(true, "defaultTraceId", Optional.empty()));
         Trace originalTrace = getTrace();
         AsyncTracer deferredTracer = new AsyncTracer();
         assertThat(originalTrace.top()).isEmpty();
@@ -48,8 +50,7 @@ public class AsyncTracerTest {
 
     @Test
     public void completesBothDeferredSpans() {
-        Tracer.initTrace(Observability.SAMPLE, "defaultTraceId");
-        Tracer.fastStartSpan("defaultSpan");
+        Tracer.initTraceWithSpan(Observability.SAMPLE, "defaultTraceId", "defaultSpan", SpanType.LOCAL);
         AsyncTracer asyncTracer = new AsyncTracer();
         List<String> observedSpans = new ArrayList<>();
         Tracer.subscribe(AsyncTracerTest.class.getName(), span -> observedSpans.add(span.getOperation()));
@@ -61,8 +62,7 @@ public class AsyncTracerTest {
 
     @Test
     public void preservesState() {
-        Tracer.initTrace(Observability.UNDECIDED, "defaultTraceId");
-        Tracer.fastStartSpan("foo");
+        Tracer.initTraceWithSpan(Observability.UNDECIDED, "defaultTraceId", "foo", SpanType.LOCAL);
         Tracer.fastStartSpan("bar");
         Tracer.fastStartSpan("baz");
         Trace originalTrace = getTrace();

--- a/tracing/src/test/java/com/palantir/tracing/DeferredTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/DeferredTracerTest.java
@@ -18,6 +18,7 @@ package com.palantir.tracing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.tracing.api.SpanType;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,7 +30,7 @@ public class DeferredTracerTest {
 
     @Test
     public void testIsSerializable() throws IOException, ClassNotFoundException {
-        Tracer.initTrace(Observability.UNDECIDED, "defaultTraceId");
+        Tracer.initTraceWithSpan(Observability.UNDECIDED, "defaultTraceId", "span", SpanType.LOCAL);
 
         DeferredTracer deferredTracer = new DeferredTracer("operation");
 
@@ -38,7 +39,7 @@ public class DeferredTracerTest {
             objectOutputStream.writeObject(deferredTracer);
         }
 
-        Tracer.initTrace(Observability.UNDECIDED, "someOtherTraceId");
+        Tracer.initTraceWithSpan(Observability.UNDECIDED, "someOtherTraceId", "span", SpanType.LOCAL);
 
         ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
         try (ObjectInputStream objectInputStream = new ObjectInputStream(bais)) {

--- a/tracing/src/test/java/com/palantir/tracing/TraceTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TraceTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palantir.tracing.api.OpenSpan;
 import com.palantir.tracing.api.SpanType;
+import java.util.Optional;
 import org.junit.Test;
 
 public final class TraceTest {
@@ -28,12 +29,12 @@ public final class TraceTest {
 
     @Test
     public void constructTrace_emptyTraceId() {
-        assertThatThrownBy(() -> Trace.of(false, "")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Trace.of(false, "", Optional.empty())).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void testToString() {
-        Trace trace = Trace.of(true, "traceId");
+        Trace trace = Trace.of(true, "traceId", Optional.empty());
         OpenSpan span = trace.startSpan("operation", SpanType.LOCAL);
         assertThat(trace.toString())
                 .isEqualTo("Trace{stack=[" + span + "], isObservable=true, traceId='traceId'}")
@@ -43,7 +44,7 @@ public final class TraceTest {
 
     @Test
     public void testOriginatingTraceId_slow_sampled() {
-        Trace trace = Trace.of(true, "traceId");
+        Trace trace = Trace.of(true, "traceId", Optional.empty());
         OpenSpan originating = trace.startSpan("1", ORIGINATING_SPAN_ID, SpanType.LOCAL);
         assertThat(originating.getOriginatingSpanId()).contains(ORIGINATING_SPAN_ID);
         OpenSpan span = trace.startSpan("2", SpanType.LOCAL);
@@ -52,7 +53,7 @@ public final class TraceTest {
 
     @Test
     public void testOriginatingTraceId_fast_sampled() {
-        Trace trace = Trace.of(true, "traceId");
+        Trace trace = Trace.of(true, "traceId", Optional.empty());
         trace.fastStartSpan("1", ORIGINATING_SPAN_ID, SpanType.LOCAL);
         OpenSpan span = trace.startSpan("2", SpanType.LOCAL);
         assertThat(span.getOriginatingSpanId()).contains(ORIGINATING_SPAN_ID);
@@ -60,7 +61,7 @@ public final class TraceTest {
 
     @Test
     public void testOriginatingTraceId_slow_unsampled() {
-        Trace trace = Trace.of(false, "traceId");
+        Trace trace = Trace.of(false, "traceId", Optional.empty());
         OpenSpan originating = trace.startSpan("1", ORIGINATING_SPAN_ID, SpanType.LOCAL);
         assertThat(originating.getOriginatingSpanId()).contains(ORIGINATING_SPAN_ID);
         OpenSpan span = trace.startSpan("2", SpanType.LOCAL);
@@ -69,7 +70,7 @@ public final class TraceTest {
 
     @Test
     public void testOriginatingTraceId_fast_unsampled() {
-        Trace trace = Trace.of(false, "traceId");
+        Trace trace = Trace.of(false, "traceId", Optional.empty());
         trace.fastStartSpan("1", ORIGINATING_SPAN_ID, SpanType.LOCAL);
         OpenSpan span = trace.startSpan("2", SpanType.LOCAL);
         assertThat(span.getOriginatingSpanId()).contains(ORIGINATING_SPAN_ID);

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -61,7 +61,7 @@ public final class TracersTest {
 
         Tracer.setSampler(AlwaysSampler.INSTANCE);
         // Initialize a new trace for each test
-        Tracer.initTrace(Observability.UNDECIDED, "defaultTraceId");
+        Tracer.setTrace(Trace.of(true, "defaultTraceId", Optional.empty()));
     }
 
     @After

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -28,10 +28,12 @@ import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.tracing.api.OpenSpan;
 import com.palantir.tracing.api.Span;
+import com.palantir.tracing.api.SpanType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -111,6 +113,24 @@ public final class TracersTest {
         wrappedService.submit(traceExpectingRunnableWithSingleSpan("operation")).get();
         Tracer.fastCompleteSpan();
         Tracer.fastCompleteSpan();
+        Tracer.fastCompleteSpan();
+    }
+
+    @Test
+    public void testWrapExecutorService_withRequestId() throws Exception {
+        ExecutorService wrappedService = Tracers.wrap("operation", Executors.newSingleThreadExecutor());
+
+        // Non-empty trace
+        Tracer.initTraceWithSpan(Observability.UNDECIDED, "traceId", "root", SpanType.SERVER_INCOMING);
+        String requestId = Tracer.maybeGetTraceMetadata()
+                .flatMap(TraceMetadata::getRequestId)
+                .get();
+        wrappedService
+                .submit(traceExpectingCallableWithSingleSpan("operation", Optional.of(requestId)))
+                .get();
+        wrappedService
+                .submit(traceExpectingRunnableWithSingleSpan("operation", Optional.of(requestId)))
+                .get();
         Tracer.fastCompleteSpan();
     }
 
@@ -913,6 +933,11 @@ public final class TracersTest {
     }
 
     private static Callable<Void> traceExpectingCallableWithSingleSpan(String operation) {
+        return traceExpectingCallableWithSingleSpan(operation, Optional.empty());
+    }
+
+    private static Callable<Void> traceExpectingCallableWithSingleSpan(
+            String operation, Optional<String> expectedRequestId) {
         final String outsideTraceId = Tracer.getTraceId();
 
         return () -> {
@@ -924,11 +949,16 @@ public final class TracersTest {
             assertThat(traceId).isEqualTo(outsideTraceId);
             assertThat(span.getOperation()).isEqualTo(operation);
             assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(outsideTraceId);
+            assertThat(MDC.get(Tracers.REQUEST_ID_KEY)).isEqualTo(expectedRequestId.orElse(null));
             return null;
         };
     }
 
     private static Runnable traceExpectingRunnableWithSingleSpan(String operation) {
+        return traceExpectingRunnableWithSingleSpan(operation, Optional.empty());
+    }
+
+    private static Runnable traceExpectingRunnableWithSingleSpan(String operation, Optional<String> expectedRequestId) {
         final String outsideTraceId = Tracer.getTraceId();
 
         return () -> {
@@ -940,6 +970,7 @@ public final class TracersTest {
             assertThat(traceId).isEqualTo(outsideTraceId);
             assertThat(span.getOperation()).isEqualTo(operation);
             assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(outsideTraceId);
+            assertThat(MDC.get(Tracers.REQUEST_ID_KEY)).isEqualTo(expectedRequestId.orElse(null));
         };
     }
 


### PR DESCRIPTION
## Before this PR
Many requests may share a single traceId, there was no identifying information to distinguish between requests.

## After this PR
==COMMIT_MSG==
Tracing uniquely identifies requests
==COMMIT_MSG==

## Possible downsides?
* The request identifier is arguably not a tracing concern, implementing it at this layer is a matter of convenience.We already wrap requests and executors with tracing-aware components, and tell tracing when a request begins and ends, making tracing an ideal candidate to house this identifier.
* Possible performance cost of generating another unique identifier for each request.

