### PR TITLE
Add `Tracer.hasUnobservableTrace()` API to simplify consumers

### DIFF
--- a/changelog/@unreleased/pr-624.v2.yml
+++ b/changelog/@unreleased/pr-624.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Add `Tracer.hasUnobservableTrace()` API to simplify tracing framework
+    implementations.
+  links:
+  - https://github.com/palantir/tracing-java/pull/624

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -627,6 +627,16 @@ public final class Tracer {
         return trace != null && trace.isObservable();
     }
 
+    /**
+     * Returns true if there is an active trace which is not observable. This is equivalent to the result of
+     * {@code Tracer.hasTraceId() && !Tracer.isTraceObservable()}.
+     * This check is used frequently in hot paths to avoid unnecessary overhead in unsampled traces.
+     */
+    public static boolean hasUnobservableTrace() {
+        Trace trace = currentTrace.get();
+        return trace != null && !trace.isObservable();
+    }
+
     /** Returns an independent copy of this thread's {@link Trace}. */
     static Optional<Trace> copyTrace() {
         Trace trace = currentTrace.get();


### PR DESCRIPTION
This makes the code easier to follow and avoids additional unnecessary threadlocal map lookups.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add `Tracer.hasUnobservableTrace()` API to simplify tracing framework implementations.
==COMMIT_MSG==

## Possible downsides?
none
