### PR TITLE
DeferredTracer avoids an unnecessary deep copy of the current trace

### DIFF
--- a/changelog/@unreleased/pr-676.v2.yml
+++ b/changelog/@unreleased/pr-676.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: DeferredTracer avoids an unnecessary deep copy of the current trace
+  links:
+  - https://github.com/palantir/tracing-java/pull/676

--- a/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
@@ -120,7 +120,7 @@ public final class DeferredTracer implements Serializable {
             return NopCloseableTrace.INSTANCE;
         }
 
-        Optional<Trace> originalTrace = Tracer.copyTrace();
+        Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
         Tracer.setTrace(Trace.of(isObservable, traceId, Optional.ofNullable(requestId)));
         if (parentSpanId != null) {


### PR DESCRIPTION
## Before this PR
The deep copy is necessary when a DeferredTracer is created, but
not just before the current trace is cleared in the body of the
deferred action.
This does not modify behavior, only reduces unnecessary overhead.

## After this PR
==COMMIT_MSG==
DeferredTracer avoids an unnecessary deep copy of the current trace
==COMMIT_MSG==

