### PR TITLE
log when clearing trace

### DIFF
--- a/changelog/@unreleased/pr-678.v2.yml
+++ b/changelog/@unreleased/pr-678.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add debug logging when clearing a thread's trace
+  links:
+  - https://github.com/palantir/tracing-java/pull/678

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -689,9 +689,17 @@ public final class Tracer {
 
     @VisibleForTesting
     static void clearCurrentTrace() {
+        logClearingTrace();
         currentTrace.remove();
         MDC.remove(Tracers.TRACE_ID_KEY);
         MDC.remove(Tracers.TRACE_SAMPLED_KEY);
         MDC.remove(Tracers.REQUEST_ID_KEY);
+    }
+
+    private static void logClearingTrace() {
+        log.debug("Clearing current trace", SafeArg.of("maybeTrace", Optional.ofNullable(currentTrace.get())));
+        if (log.isTraceEnabled()) {
+            log.trace("Stacktrace at time of clearing trace", new SafeRuntimeException("not a real exception"));
+        }
     }
 }

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -657,6 +657,8 @@ public final class Tracer {
         MDC.put(Tracers.TRACE_ID_KEY, trace.getTraceId());
         setTraceSampledMdcIfObservable(trace.isObservable());
         setTraceRequestId(trace.getRequestId());
+
+        logSettingTrace(trace);
     }
 
     private static void setTraceSampledMdcIfObservable(boolean observable) {
@@ -675,6 +677,12 @@ public final class Tracer {
         } else {
             // Ensure MDC state is cleared when there is no request identifier
             MDC.remove(Tracers.REQUEST_ID_KEY);
+        }
+    }
+
+    private static void logSettingTrace(Trace trace) {
+        if (log.isDebugEnabled()) {
+            log.debug("Setting trace", SafeArg.of("trace", trace));
         }
     }
 
@@ -697,7 +705,9 @@ public final class Tracer {
     }
 
     private static void logClearingTrace() {
-        log.debug("Clearing current trace", SafeArg.of("maybeTrace", Optional.ofNullable(currentTrace.get())));
+        if (log.isDebugEnabled()) {
+            log.debug("Clearing current trace", SafeArg.of("trace", currentTrace.get()));
+        }
         if (log.isTraceEnabled()) {
             log.trace("Stacktrace at time of clearing trace", new SafeRuntimeException("not a real exception"));
         }

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -658,7 +658,7 @@ public final class Tracer {
         setTraceSampledMdcIfObservable(trace.isObservable());
         setTraceRequestId(trace.getRequestId());
 
-        logSettingTrace(trace);
+        logSettingTrace();
     }
 
     private static void setTraceSampledMdcIfObservable(boolean observable) {
@@ -680,10 +680,8 @@ public final class Tracer {
         }
     }
 
-    private static void logSettingTrace(Trace trace) {
-        if (log.isDebugEnabled()) {
-            log.debug("Setting trace", SafeArg.of("trace", trace));
-        }
+    private static void logSettingTrace() {
+        log.debug("Setting trace");
     }
 
     private static Trace getOrCreateCurrentTrace() {
@@ -707,9 +705,9 @@ public final class Tracer {
     private static void logClearingTrace() {
         if (log.isDebugEnabled()) {
             log.debug("Clearing current trace", SafeArg.of("trace", currentTrace.get()));
-        }
-        if (log.isTraceEnabled()) {
-            log.trace("Stacktrace at time of clearing trace", new SafeRuntimeException("not a real exception"));
+            if (log.isTraceEnabled()) {
+                log.trace("Stacktrace at time of clearing trace", new SafeRuntimeException("not a real exception"));
+            }
         }
     }
 }


### PR DESCRIPTION
We're seeing instances of trace information disappearing from logs on a thread that previously had traceIds. Trying to track down where/how they're getting cleared.

==COMMIT_MSG==
debug logging when clearing trace
==COMMIT_MSG==
