### PR TITLE
add Tracers.wrapSupplier

### DIFF
--- a/changelog/@unreleased/pr-681.v2.yml
+++ b/changelog/@unreleased/pr-681.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add Tracers.wrapSupplier to wrap a Supplier with tracing.
+  links:
+  - https://github.com/palantir/tracing-java/pull/681

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -165,7 +165,7 @@ public final class Tracers {
 
     /**
      * Wraps the given {@link Callable} such that it uses the thread-local {@link Trace tracing state} at the time of
-     * it's construction during its {@link Callable#call() execution}.
+     * its construction during its {@link Callable#call() execution}.
      */
     public static <V> Callable<V> wrap(Callable<V> delegate) {
         return new TracingAwareCallable<>(Optional.empty(), delegate);
@@ -181,7 +181,7 @@ public final class Tracers {
 
     /**
      * Wraps the given {@link Runnable} such that it uses the thread-local {@link Trace tracing state} at the time of
-     * it's construction during its {@link Runnable#run()} execution}.
+     * its construction during its {@link Runnable#run()} execution}.
      */
     public static Runnable wrap(Runnable delegate) {
         return new TracingAwareRunnable(Optional.empty(), delegate);
@@ -197,18 +197,11 @@ public final class Tracers {
 
     /**
      * Wraps the given {@link Supplier} such that it uses the thread-local {@link Trace tracing state} at the time of
-     * it's construction during its {@link Supplier#get() execution}.
-     */
-    public static <V> Supplier<V> wrapSupplier(Supplier<V> delegate) {
-        return new TracingAwareSupplier<>(Optional.empty(), delegate);
-    }
-
-    /**
-     * Like {@link #wrapSupplier(Supplier)}, but using the given {@link String operation} is used to create a span for
-     * the execution.
+     * its construction during its {@link Supplier#get() execution}. It uses the given {@link String operation} is
+     * used to create a span for the execution.
      */
     public static <V> Supplier<V> wrapSupplier(String operation, Supplier<V> delegate) {
-        return new TracingAwareSupplier<>(Optional.of(operation), delegate);
+        return new TracingAwareSupplier<>(operation, delegate);
     }
 
     /**
@@ -484,7 +477,7 @@ public final class Tracers {
         private final Supplier<V> delegate;
         private final DeferredTracer deferredTracer;
 
-        TracingAwareSupplier(Optional<String> operation, Supplier<V> delegate) {
+        TracingAwareSupplier(String operation, Supplier<V> delegate) {
             this.delegate = delegate;
             this.deferredTracer = new DeferredTracer(operation);
         }

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -172,7 +172,7 @@ public final class Tracers {
     }
 
     /**
-     * Like {@link #wrap(Supplier)}, but using the given {@link String operation} is used to create a span for the
+     * Like {@link #wrapSupplier(Supplier)}, but using the given {@link String operation} is used to create a span for the
      * execution.
      */
     public static <V> Supplier<V> wrapSupplier(String operation, Supplier<V> delegate) {

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -164,22 +164,6 @@ public final class Tracers {
     }
 
     /**
-     * Wraps the given {@link Supplier} such that it uses the thread-local {@link Trace tracing state} at the time of
-     * it's construction during its {@link Supplier#get() execution}.
-     */
-    public static <V> Supplier<V> wrapSupplier(Supplier<V> delegate) {
-        return new TracingAwareSupplier<>(Optional.empty(), delegate);
-    }
-
-    /**
-     * Like {@link #wrapSupplier(Supplier)}, but using the given {@link String operation} is used to create a span for the
-     * execution.
-     */
-    public static <V> Supplier<V> wrapSupplier(String operation, Supplier<V> delegate) {
-        return new TracingAwareSupplier<>(Optional.of(operation), delegate);
-    }
-
-    /**
      * Wraps the given {@link Callable} such that it uses the thread-local {@link Trace tracing state} at the time of
      * it's construction during its {@link Callable#call() execution}.
      */
@@ -209,6 +193,22 @@ public final class Tracers {
      */
     public static Runnable wrap(String operation, Runnable delegate) {
         return new TracingAwareRunnable(Optional.of(operation), delegate);
+    }
+
+    /**
+     * Wraps the given {@link Supplier} such that it uses the thread-local {@link Trace tracing state} at the time of
+     * it's construction during its {@link Supplier#get() execution}.
+     */
+    public static <V> Supplier<V> wrapSupplier(Supplier<V> delegate) {
+        return new TracingAwareSupplier<>(Optional.empty(), delegate);
+    }
+
+    /**
+     * Like {@link #wrapSupplier(Supplier)}, but using the given {@link String operation} is used to create a span for
+     * the execution.
+     */
+    public static <V> Supplier<V> wrapSupplier(String operation, Supplier<V> delegate) {
+        return new TracingAwareSupplier<>(Optional.of(operation), delegate);
     }
 
     /**


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
There is wrap(Callable) but that is suboptimal because Callable.call throws Exception.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add Tracers.wrapSupplier to wrap a Supplier with tracing.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
None. The name is suboptimal because java can't decide if a lambda should be a callable or a supplier.

