### PR TITLE
Use SOURCE retention for immutables style annotations

### DIFF
--- a/tracing-api/src/main/java/com/palantir/tracing/api/ImmutablesStyle.java
+++ b/tracing-api/src/main/java/com/palantir/tracing/api/ImmutablesStyle.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-apply from: "${rootDir}/gradle/publish-jar.gradle"
-apply plugin: 'com.palantir.revapi'
+package com.palantir.tracing.api;
 
-dependencies {
-    compile project(":tracing")
-    compile "com.squareup.okhttp3:okhttp"
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.immutables.value.Value;
 
-    implementation project(':tracing-api')
-
-    testImplementation "junit:junit"
-    testImplementation "org.assertj:assertj-core"
-    testImplementation "org.mockito:mockito-core"
-}
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Retention(RetentionPolicy.SOURCE)
+@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@interface ImmutablesStyle {}

--- a/tracing-api/src/main/java/com/palantir/tracing/api/OpenSpan.java
+++ b/tracing-api/src/main/java/com/palantir/tracing/api/OpenSpan.java
@@ -26,7 +26,7 @@ import org.immutables.value.Value;
  * {@link Span} object.
  */
 @Value.Immutable
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@ImmutablesStyle
 public abstract class OpenSpan {
     private static final Clock CLOCK = Clock.systemUTC();
 

--- a/tracing-api/src/main/java/com/palantir/tracing/api/Span.java
+++ b/tracing-api/src/main/java/com/palantir/tracing/api/Span.java
@@ -22,7 +22,7 @@ import org.immutables.value.Value;
 
 /** A value class representing a completed Span, see {@link OpenSpan} for a description of the fields. */
 @Value.Immutable
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@ImmutablesStyle
 public abstract class Span {
 
     public abstract String getTraceId();

--- a/tracing-jaxrs/build.gradle
+++ b/tracing-jaxrs/build.gradle
@@ -28,8 +28,4 @@ dependencies {
     testImplementation "org.assertj:assertj-core"
     testImplementation "org.jmock:jmock"
     testImplementation "org.mockito:mockito-core"
-
-    annotationProcessor "org.immutables:value"
-    compileOnly "org.immutables:value::annotations"
-    testCompileOnly "org.immutables:value::annotations"
 }

--- a/tracing-jersey/build.gradle
+++ b/tracing-jersey/build.gradle
@@ -30,7 +30,4 @@ dependencies {
     testImplementation "org.assertj:assertj-core"
     testImplementation "org.hamcrest:hamcrest-all"
     testImplementation "org.mockito:mockito-core"
-
-    compileOnly "org.immutables:value::annotations"
-    testCompileOnly "org.immutables:value::annotations"
 }

--- a/tracing-servlet/build.gradle
+++ b/tracing-servlet/build.gradle
@@ -29,7 +29,4 @@ dependencies {
     testImplementation "io.dropwizard:dropwizard-testing"
     testImplementation "junit:junit"
     testImplementation 'org.assertj:assertj-core'
-
-    compileOnly "org.immutables:value::annotations"
-    testCompileOnly "org.immutables:value::annotations"
 }

--- a/tracing-undertow/build.gradle
+++ b/tracing-undertow/build.gradle
@@ -31,7 +31,4 @@ dependencies {
     testImplementation 'junit:junit'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.mockito:mockito-core'
-
-    compileOnly "org.immutables:value::annotations"
-    testCompileOnly "org.immutables:value::annotations"
 }

--- a/tracing/build.gradle
+++ b/tracing/build.gradle
@@ -42,5 +42,4 @@ dependencies {
 
     annotationProcessor "org.immutables:value"
     compileOnly "org.immutables:value::annotations"
-    testCompileOnly "org.immutables:value::annotations"
 }

--- a/tracing/src/main/java/com/palantir/tracing/AsyncSlf4jSpanObserver.java
+++ b/tracing/src/main/java/com/palantir/tracing/AsyncSlf4jSpanObserver.java
@@ -58,7 +58,7 @@ public final class AsyncSlf4jSpanObserver extends AsyncSpanObserver {
 
     @JsonSerialize(as = ImmutableZipkinCompatSpan.class)
     @Value.Immutable
-    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    @ImmutablesStyle
     abstract static class ZipkinCompatSpan {
 
         abstract String getTraceId();
@@ -141,7 +141,7 @@ public final class AsyncSlf4jSpanObserver extends AsyncSpanObserver {
 
     @JsonSerialize(as = ImmutableZipkinCompatAnnotation.class)
     @Value.Immutable
-    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    @ImmutablesStyle
     abstract static class ZipkinCompatAnnotation {
         abstract long timestamp(); // epoch microseconds
 
@@ -160,7 +160,7 @@ public final class AsyncSlf4jSpanObserver extends AsyncSpanObserver {
 
     @JsonSerialize(as = ImmutableZipkinCompatBinaryAnnotation.class)
     @Value.Immutable
-    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    @ImmutablesStyle
     abstract static class ZipkinCompatBinaryAnnotation {
 
         abstract String key();
@@ -180,7 +180,7 @@ public final class AsyncSlf4jSpanObserver extends AsyncSpanObserver {
 
     @JsonSerialize(as = ImmutableZipkinCompatEndpoint.class)
     @Value.Immutable
-    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    @ImmutablesStyle
     @JsonInclude(JsonInclude.Include.NON_NULL)
     abstract static class ZipkinCompatEndpoint {
         abstract String serviceName();

--- a/tracing/src/main/java/com/palantir/tracing/ImmutablesStyle.java
+++ b/tracing/src/main/java/com/palantir/tracing/ImmutablesStyle.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-apply from: "${rootDir}/gradle/publish-jar.gradle"
-apply plugin: 'com.palantir.revapi'
+package com.palantir.tracing;
 
-dependencies {
-    compile project(":tracing")
-    compile "com.squareup.okhttp3:okhttp"
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.immutables.value.Value;
 
-    implementation project(':tracing-api')
-
-    testImplementation "junit:junit"
-    testImplementation "org.assertj:assertj-core"
-    testImplementation "org.mockito:mockito-core"
-}
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Retention(RetentionPolicy.SOURCE)
+@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@interface ImmutablesStyle {}

--- a/tracing/src/main/java/com/palantir/tracing/TraceMetadata.java
+++ b/tracing/src/main/java/com/palantir/tracing/TraceMetadata.java
@@ -21,7 +21,7 @@ import org.immutables.value.Value;
 
 /** Ids necessary to write headers onto network requests. */
 @Value.Immutable
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@ImmutablesStyle
 public interface TraceMetadata {
 
     /** Corresponds to {@link com.palantir.tracing.api.TraceHttpHeaders#TRACE_ID}. */


### PR DESCRIPTION
See https://github.com/immutables/immutables/issues/291.

Example of similar fix in https://github.com/palantir/conjure-java-runtime-api/pull/369.

This eliminates compilation warnings for consumers that do not directly depend on immutables.