### PR TITLE
Decrease default sample rate from 1% to .05% to match internal tools

### DIFF
--- a/changelog/@unreleased/pr-698.v2.yml
+++ b/changelog/@unreleased/pr-698.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Decrease default sample rate from 1% to .05% to match internal tools
+  links:
+  - https://github.com/palantir/tracing-java/pull/698

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -67,7 +67,7 @@ public final class Tracer {
     private static volatile Consumer<Span> compositeObserver = _span -> {};
 
     // Thread-safe since stateless
-    private static volatile TraceSampler sampler = RandomSampler.create(0.01f);
+    private static volatile TraceSampler sampler = RandomSampler.create(0.005f);
 
     /** Creates a new trace, but does not set it as the current trace. */
     private static Trace createTrace(Observability observability, String traceId, Optional<String> requestId) {

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -67,7 +67,7 @@ public final class Tracer {
     private static volatile Consumer<Span> compositeObserver = _span -> {};
 
     // Thread-safe since stateless
-    private static volatile TraceSampler sampler = RandomSampler.create(0.005f);
+    private static volatile TraceSampler sampler = RandomSampler.create(0.0005f);
 
     /** Creates a new trace, but does not set it as the current trace. */
     private static Trace createTrace(Observability observability, String traceId, Optional<String> requestId) {


### PR DESCRIPTION
## Before this PR
More sampled traces.

## After this PR
==COMMIT_MSG==
Decrease default sample rate from 1% to .05% to match internal tools
==COMMIT_MSG==

## Possible downsides?
Fewer sampled traces. That's the point though.