### PR TITLE
Implement helpers for TagTranslator ease of use

### DIFF
--- a/changelog/@unreleased/pr-717.v2.yml
+++ b/changelog/@unreleased/pr-717.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: TagTranslator quality of life improvements
+  links:
+  - https://github.com/palantir/tracing-java/pull/717

--- a/tracing/src/main/java/com/palantir/tracing/CompositeTagTranslator.java
+++ b/tracing/src/main/java/com/palantir/tracing/CompositeTagTranslator.java
@@ -16,6 +16,8 @@
 
 package com.palantir.tracing;
 
+import com.palantir.logsafe.Preconditions;
+
 /**
  * Default implementation of {@link TagTranslator} used by {@link TagTranslator#andThen(TagTranslator)}.
  */
@@ -25,8 +27,8 @@ final class CompositeTagTranslator<S> implements TagTranslator<S> {
     private final TagTranslator<? super S> second;
 
     CompositeTagTranslator(TagTranslator<? super S> first, TagTranslator<? super S> second) {
-        this.first = first;
-        this.second = second;
+        this.first = Preconditions.checkNotNull(first, "First TagTranslator is required");
+        this.second = Preconditions.checkNotNull(second, "Second TagTranslator is required");
     }
 
     @Override

--- a/tracing/src/main/java/com/palantir/tracing/CompositeTagTranslator.java
+++ b/tracing/src/main/java/com/palantir/tracing/CompositeTagTranslator.java
@@ -1,0 +1,47 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tracing;
+
+/**
+ * Default implementation of {@link TagTranslator} used by {@link TagTranslator#andThen(TagTranslator)}.
+ */
+final class CompositeTagTranslator<S> implements TagTranslator<S> {
+
+    private final TagTranslator<? super S> first;
+    private final TagTranslator<? super S> second;
+
+    CompositeTagTranslator(TagTranslator<? super S> first, TagTranslator<? super S> second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    @Override
+    public <T> void translate(TagAdapter<T> adapter, T target, S data) {
+        first.translate(adapter, target, data);
+        second.translate(adapter, target, data);
+    }
+
+    @Override
+    public boolean isEmpty(S data) {
+        return first.isEmpty(data) && second.isEmpty(data);
+    }
+
+    @Override
+    public String toString() {
+        return "CompositeTagTranslator{first=" + first + ", second=" + second + '}';
+    }
+}

--- a/tracing/src/main/java/com/palantir/tracing/TagTranslator.java
+++ b/tracing/src/main/java/com/palantir/tracing/TagTranslator.java
@@ -50,8 +50,13 @@ public interface TagTranslator<S> {
      * required to implement. It is always safe to return {@code false} even if
      * {@link #translate(TagAdapter, Object, Object)} may not produce any tags.
      */
-    default boolean isEmpty(S _data) {
+    default boolean isEmpty(@SuppressWarnings("unused") S data) {
         return false;
+    }
+
+    /** Returns a new composed {@link TagTranslator}. */
+    default TagTranslator<S> andThen(TagTranslator<? super S> after) {
+        return new CompositeTagTranslator<>(this, after);
     }
 
     /**

--- a/tracing/src/test/java/com/palantir/tracing/TagTranslatorTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TagTranslatorTest.java
@@ -29,7 +29,7 @@ public class TagTranslatorTest {
         AtomicInteger stringTranslatorCalled = new AtomicInteger();
         TagTranslator<String> translator1 = new TagTranslator<String>() {
             @Override
-            public <T> void translate(TagAdapter<T> adapter, T target, String data) {
+            public <T> void translate(TagAdapter<T> _adapter, T _target, String _data) {
                 stringTranslatorCalled.incrementAndGet();
             }
 

--- a/tracing/src/test/java/com/palantir/tracing/TagTranslatorTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TagTranslatorTest.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tracing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+public class TagTranslatorTest {
+
+    @Test
+    public void testCombine() {
+        AtomicInteger stringTranslatorCalled = new AtomicInteger();
+        TagTranslator<String> translator1 = new TagTranslator<String>() {
+            @Override
+            public <T> void translate(TagAdapter<T> adapter, T target, String data) {
+                stringTranslatorCalled.incrementAndGet();
+            }
+
+            @Override
+            public boolean isEmpty(String data) {
+                return data.isEmpty();
+            }
+        };
+        TagTranslator<String> combined = translator1.andThen(NoTagTranslator.INSTANCE);
+        assertThat(combined.isEmpty("")).isTrue();
+        combined.translate(NopTagAdapter.INSTANCE, NopTagAdapter.INSTANCE, "value");
+        assertThat(stringTranslatorCalled).hasValue(1);
+    }
+
+    private enum NopTagAdapter implements TagTranslator.TagAdapter<NopTagAdapter> {
+        INSTANCE;
+
+        @Override
+        public void tag(NopTagAdapter _target, String _key, String _value) {}
+
+        @Override
+        public void tag(NopTagAdapter _target, Map<String, String> _tags) {}
+    }
+}


### PR DESCRIPTION
Translators can be combined similarly to java functional
consumers using an `andThen` method.

Translator.isEmpty uses `@SuppressWarnings("unused")` rather than
an underscore to make IDE interactions easier when overriding
the method, this way the `data` variable name can be used as is.

==COMMIT_MSG==
TagTranslator quality of life improvements
==COMMIT_MSG==

