### PR TITLE
Tracer gracefully handles null tags

### DIFF
--- a/changelog/@unreleased/pr-718.v2.yml
+++ b/changelog/@unreleased/pr-718.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Tracer gracefully handles null tags. Not a problem, but will be helpful once we start adding more standard http tags from nullable sources.
+  links:
+  - https://github.com/palantir/tracing-java/pull/718

--- a/tracing/src/main/java/com/palantir/tracing/TagTranslator.java
+++ b/tracing/src/main/java/com/palantir/tracing/TagTranslator.java
@@ -59,14 +59,9 @@ public interface TagTranslator<S> {
         return new CompositeTagTranslator<>(this, after);
     }
 
-    /**
-     * Tag adapter object which insulates the implementation of the underlying data structure from callers.
-     */
+    /** Tag adapter object which insulates the implementation of the underlying data structure from callers. */
     interface TagAdapter<T> {
-        /**
-         * Implementations should ignore calls with {@code null} key or value, however implementations aren't
-         * expected to tread these as nullable.
-         */
+        /** No information will be recorded if either {@code key} or {@code value} are {@code null}. */
         void tag(T target, String key, String value);
 
         void tag(T target, Map<String, String> tags);

--- a/tracing/src/main/java/com/palantir/tracing/TagTranslator.java
+++ b/tracing/src/main/java/com/palantir/tracing/TagTranslator.java
@@ -63,6 +63,10 @@ public interface TagTranslator<S> {
      * Tag adapter object which insulates the implementation of the underlying data structure from callers.
      */
     interface TagAdapter<T> {
+        /**
+         * Implementations should ignore calls with {@code null} key or value, however implementations aren't
+         * expected to tread these as nullable.
+         */
         void tag(T target, String key, String value);
 
         void tag(T target, Map<String, String> tags);

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -604,7 +604,9 @@ public final class Tracer {
 
         @Override
         public void tag(Span.Builder target, String key, String value) {
-            target.putMetadata(key, value);
+            if (key != null && value != null) {
+                target.putMetadata(key, value);
+            }
         }
 
         @Override

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -59,6 +59,12 @@ public final class TracerTest {
     private ArgumentCaptor<Span> spanCaptor;
 
     @After
+    public void before() {
+        Tracer.getAndClearTraceIfPresent();
+        Tracer.setSampler(AlwaysSampler.INSTANCE);
+    }
+
+    @After
     public void after() {
         Tracer.initTraceWithSpan(Observability.SAMPLE, Tracers.randomId(), "op", SpanType.LOCAL);
         Tracer.setSampler(AlwaysSampler.INSTANCE);
@@ -257,6 +263,31 @@ public final class TracerTest {
         Optional<Span> maybeSpan = Tracer.completeSpan(metadata);
         assertThat(maybeSpan).isPresent();
         assertThat(maybeSpan.get().getMetadata()).isEqualTo(metadata);
+    }
+
+    @Test
+    public void testMetadataNullIgnored() {
+        Tracer.subscribe("1", observer1);
+        try {
+            Tracer.fastStartSpan("operation");
+            Tracer.fastCompleteSpan(
+                    new TagTranslator<String>() {
+                        @Override
+                        public <T> void translate(TagAdapter<T> adapter, T target, String data) {
+                            adapter.tag(target, "foo", null);
+                            adapter.tag(target, null, "bar");
+                            adapter.tag(target, "baz", "bang");
+                        }
+                    },
+                    "str");
+        } finally {
+            Tracer.unsubscribe("1");
+        }
+
+        verify(observer1).consume(spanCaptor.capture());
+        Span span = spanCaptor.getValue();
+        assertThat(span.getOperation()).isEqualTo("operation");
+        assertThat(span.getMetadata()).isEqualTo(ImmutableMap.of("baz", "bang"));
     }
 
     @Test

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -273,7 +273,7 @@ public final class TracerTest {
             Tracer.fastCompleteSpan(
                     new TagTranslator<String>() {
                         @Override
-                        public <T> void translate(TagAdapter<T> adapter, T target, String data) {
+                        public <T> void translate(TagAdapter<T> adapter, T target, String _data) {
                             adapter.tag(target, "foo", null);
                             adapter.tag(target, null, "bar");
                             adapter.tag(target, "baz", "bang");


### PR DESCRIPTION
==COMMIT_MSG==
Tracer gracefully handles null tags. Not a problem, but will be helpful once we start adding more standard http tags from nullable sources.
==COMMIT_MSG==

