### PR TITLE
Redact the HTTP_URL_HOST constant for now

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -9,6 +9,11 @@ acceptedBreaks:
       new: "method <T> void com.palantir.tracing.DetachedSpan::complete(com.palantir.tracing.TagTranslator<?\
         \ super T>, T)"
       justification: "new methods on provided interfaces"
+  "4.18.0":
+    com.palantir.tracing:tracing-api:
+    - code: "java.field.removedWithConstant"
+      old: "field com.palantir.tracing.api.TraceTags.HTTP_URL_HOST"
+      justification: "HTTP_URL_HOST should have been commented when it was added"
   "4.5.2":
     com.palantir.tracing:tracing:
     - code: "java.method.addedToInterface"

--- a/changelog/@unreleased/pr-722.v2.yml
+++ b/changelog/@unreleased/pr-722.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Redact the HTTP_URL_HOST constant for now
+  links:
+  - https://github.com/palantir/tracing-java/pull/722

--- a/tracing-api/src/main/java/com/palantir/tracing/api/TraceTags.java
+++ b/tracing-api/src/main/java/com/palantir/tracing/api/TraceTags.java
@@ -70,8 +70,8 @@ public final class TraceTags {
     // The data would likely be unsafe to share anyhow.
 
     // 'http.url_details.host' may contain unsafe data and is currently excluded out of caution.
-    /** The HTTP host part of the URL. */
-    public static final String HTTP_URL_HOST = "http.url_details.host";
+    // /** The HTTP host part of the URL. */
+    // public static final String HTTP_URL_HOST = "http.url_details.host";
     /** The HTTP port part of the URL. */
     public static final String HTTP_URL_PORT = "http.url_details.port";
     /**


### PR DESCRIPTION
Better to remove now than later.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Redact the HTTP_URL_HOST constant for now
==COMMIT_MSG==

## Possible downsides?
technically a break.
