### PR TITLE
Jersey tracing uses standardized tags

### DIFF
--- a/changelog/@unreleased/pr-723.v2.yml
+++ b/changelog/@unreleased/pr-723.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Jersey tracing uses standardized tags
+  links:
+  - https://github.com/palantir/tracing-java/pull/723

--- a/tracing-jersey/src/test/java/com/palantir/tracing/jersey/TraceEnrichingFilterTest.java
+++ b/tracing-jersey/src/test/java/com/palantir/tracing/jersey/TraceEnrichingFilterTest.java
@@ -175,7 +175,10 @@ public final class TraceEnrichingFilterTest {
         Span span = spanCaptor.getValue();
         assertThat(span.getOperation()).isEqualTo("Jersey: POST /trace");
         assertThat(span.getMetadata())
-                .containsEntry(TraceTags.HTTP_STATUS_CODE, Integer.toString(response.getStatus()));
+                .containsEntry(TraceTags.HTTP_STATUS_CODE, Integer.toString(response.getStatus()))
+                .containsEntry(TraceTags.HTTP_URL_PATH_TEMPLATE, "/trace")
+                .containsEntry(TraceTags.HTTP_METHOD, "POST")
+                .containsKey(TraceTags.HTTP_REQUEST_ID);
     }
 
     @Test


### PR DESCRIPTION
Note that the operation name is still dynamic based on verb and path.

==COMMIT_MSG==
Jersey tracing uses standardized tags
==COMMIT_MSG==

