### PR TITLE
Undertow tracing supports configurable root request spans

### DIFF
--- a/changelog/@unreleased/pr-725.v2.yml
+++ b/changelog/@unreleased/pr-725.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Undertow tracing supports configurable root request spans
+  links:
+  - https://github.com/palantir/tracing-java/pull/725

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedOperationHandler.java
@@ -63,8 +63,8 @@ public final class TracedOperationHandler implements HttpHandler {
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         // The configured tags apply to this handler, not the full request span. We expect the full request span to
         // be initialized prior to traced operations.
-        DetachedSpan detachedSpan =
-                UndertowTracing.getOrInitializeRequestTrace(exchange, StatusCodeTagTranslator.INSTANCE);
+        DetachedSpan detachedSpan = UndertowTracing.getOrInitializeRequestTrace(
+                exchange, "Undertow Request", StatusCodeTagTranslator.INSTANCE);
         try (CloseableSpan ignored = detachedSpan.childSpan(operation, translator, exchange)) {
             delegate.handleRequest(exchange);
         }

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedRequestHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedRequestHandler.java
@@ -33,12 +33,21 @@ import io.undertow.server.HttpServerExchange;
  */
 public final class TracedRequestHandler implements HttpHandler {
 
+    private static final String DEFAULT_OPERATION_NAME = "Undertow Request";
+
     private final HttpHandler delegate;
+    private final String operationName;
     private final TagTranslator<? super HttpServerExchange> translator;
 
-    public TracedRequestHandler(HttpHandler delegate, TagTranslator<? super HttpServerExchange> translator) {
+    public TracedRequestHandler(
+            HttpHandler delegate, String operationName, TagTranslator<? super HttpServerExchange> translator) {
         this.delegate = Preconditions.checkNotNull(delegate, "HttpHandler is required");
+        this.operationName = Preconditions.checkNotNull(operationName, "Operation name is required");
         this.translator = Preconditions.checkNotNull(translator, "TagTranslator is required");
+    }
+
+    public TracedRequestHandler(HttpHandler delegate, TagTranslator<? super HttpServerExchange> translator) {
+        this(delegate, DEFAULT_OPERATION_NAME, translator);
     }
 
     public TracedRequestHandler(HttpHandler delegate) {
@@ -47,12 +56,12 @@ public final class TracedRequestHandler implements HttpHandler {
 
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
-        UndertowTracing.getOrInitializeRequestTrace(exchange, translator);
+        UndertowTracing.getOrInitializeRequestTrace(exchange, operationName, translator);
         delegate.handleRequest(exchange);
     }
 
     @Override
     public String toString() {
-        return "TracedRequestHandler{delegate=" + delegate + '}';
+        return "TracedRequestHandler{delegate=" + delegate + ", operationName='" + operationName + "'}";
     }
 }

--- a/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedRequestHandlerTest.java
+++ b/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedRequestHandlerTest.java
@@ -81,6 +81,7 @@ public class TracedRequestHandlerTest {
                         .put(
                                 HttpString.tryFromString("requestId"),
                                 exchange.getAttachment(TracingAttachments.REQUEST_ID)),
+                "TracedRequestHandlerTest",
                 new TagTranslator<HttpServerExchange>() {
                     @Override
                     public <T> void translate(TagAdapter<T> adapter, T target, HttpServerExchange data) {
@@ -122,7 +123,7 @@ public class TracedRequestHandlerTest {
         verifyNoMoreInteractions(traceSampler);
         verify(observer).consume(spanCaptor.capture());
         Span span = spanCaptor.getValue();
-        assertThat(span.getOperation()).isEqualTo("Undertow Request");
+        assertThat(span.getOperation()).isEqualTo("TracedRequestHandlerTest");
         assertThat(span.getTraceId()).isEqualTo("1234");
         assertThat(span.getMetadata())
                 .containsEntry(TraceTags.HTTP_STATUS_CODE, Integer.toString(con.getResponseCode()));
@@ -151,7 +152,7 @@ public class TracedRequestHandlerTest {
         verifyNoMoreInteractions(traceSampler);
         verify(observer).consume(spanCaptor.capture());
         Span span = spanCaptor.getValue();
-        assertThat(span.getOperation()).isEqualTo("Undertow Request");
+        assertThat(span.getOperation()).isEqualTo("TracedRequestHandlerTest");
         assertThat(span.getTraceId()).isEqualTo(reportedTraceId);
         assertThat(span.getMetadata())
                 .containsEntry(TraceTags.HTTP_STATUS_CODE, Integer.toString(con.getResponseCode()));
@@ -169,7 +170,7 @@ public class TracedRequestHandlerTest {
         verifyNoMoreInteractions(traceSampler);
         verify(observer).consume(spanCaptor.capture());
         Span span = spanCaptor.getValue();
-        assertThat(span.getOperation()).isEqualTo("Undertow Request");
+        assertThat(span.getOperation()).isEqualTo("TracedRequestHandlerTest");
         assertThat(span.getTraceId()).isEqualTo(reportedTraceId);
         assertThat(span.getMetadata())
                 .containsEntry(TraceTags.HTTP_STATUS_CODE, Integer.toString(con.getResponseCode()));
@@ -193,7 +194,7 @@ public class TracedRequestHandlerTest {
         verifyNoMoreInteractions(traceSampler);
         verify(observer).consume(spanCaptor.capture());
         Span span = spanCaptor.getValue();
-        assertThat(span.getOperation()).isEqualTo("Undertow Request");
+        assertThat(span.getOperation()).isEqualTo("TracedRequestHandlerTest");
         assertThat(span.getTraceId()).isEqualTo("1234");
         assertThat(span.getMetadata())
                 .doesNotContainKey(TraceTags.HTTP_STATUS_CODE)


### PR DESCRIPTION
This will be leveraged to reintroduce endpoint information
into the span name to allow aggregation across individual
endpoints, rather than _all_ endpoints.

==COMMIT_MSG==
Undertow tracing supports configurable root request spans
==COMMIT_MSG==

