### PR TITLE
Allow conjure-undertow to leverage the `DetachedSpan.attach()` mechanism

### DIFF
--- a/changelog/@unreleased/pr-773.v2.yml
+++ b/changelog/@unreleased/pr-773.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Allow conjure-undertow to leverage the `DetachedSpan.attach()` mechanism
+    without creating spans for blocking work
+  links:
+  - https://github.com/palantir/tracing-java/pull/773

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedStateHandler.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracedStateHandler.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tracing.undertow;
+
+import com.palantir.logsafe.Preconditions;
+import com.palantir.tracing.CloseableSpan;
+import com.palantir.tracing.DetachedSpan;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+
+/**
+ * Handler applies existing tracing state associated with the {@link HttpServerExchange} to the current thread
+ * without additional tracing spans. This ensures that logging has the correct {@code traceId} and
+ * standard tracing uses are associated with the request span.
+ */
+public final class TracedStateHandler implements HttpHandler {
+    private final HttpHandler delegate;
+
+    public TracedStateHandler(HttpHandler delegate) {
+        this.delegate = Preconditions.checkNotNull(delegate, "A delegate HttpHandler is required");
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        // We expect that TracedRequestHandler has already been invoked, however we create a generic request
+        // span in the off-chance it hasn't.
+        DetachedSpan detachedSpan = UndertowTracing.getOrInitializeRequestTrace(
+                exchange, "Undertow Request", StatusCodeTagTranslator.INSTANCE);
+        try (CloseableSpan ignored = detachedSpan.attach()) {
+            delegate.handleRequest(exchange);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "TracedStateHandler{" + delegate + '}';
+    }
+}

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/UndertowTracing.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/UndertowTracing.java
@@ -16,7 +16,6 @@
 
 package com.palantir.tracing.undertow;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
@@ -37,7 +36,8 @@ import io.undertow.util.HttpString;
 import java.util.Optional;
 
 /**
- * Internal utility functionality shared between {@link TracedOperationHandler} and {@link TracedRequestHandler}.
+ * Internal utility functionality shared between {@link TracedRequestHandler}, {@link TracedStateHandler}, and
+ * {@link TracedOperationHandler}.
  * Intentionally package private.
  */
 final class UndertowTracing {
@@ -54,7 +54,6 @@ final class UndertowTracing {
     /**
      * Detached span object representing the entire request including asynchronous components.
      */
-    @VisibleForTesting
     static final AttachmentKey<DetachedSpan> REQUEST_SPAN = AttachmentKey.create(DetachedSpan.class);
 
     private static final AttachmentKey<TagTranslator<? super HttpServerExchange>> TAG_TRANSLATOR_ATTACHMENT_KEY =

--- a/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedStateHandlerTest.java
+++ b/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedStateHandlerTest.java
@@ -1,0 +1,215 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tracing.undertow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.palantir.tracing.TraceMetadata;
+import com.palantir.tracing.TraceSampler;
+import com.palantir.tracing.Tracer;
+import com.palantir.tracing.Tracers;
+import com.palantir.tracing.api.Span;
+import com.palantir.tracing.api.SpanObserver;
+import com.palantir.tracing.api.TraceHttpHeaders;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderMap;
+import io.undertow.util.HttpString;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import org.slf4j.MDC;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TracedStateHandlerTest {
+
+    @Captor
+    private ArgumentCaptor<Span> spanCaptor;
+
+    @Mock
+    private SpanObserver observer;
+
+    @Mock
+    private TraceSampler traceSampler;
+
+    @Mock
+    private HttpHandler delegate;
+
+    private HttpServerExchange exchange = HttpServerExchanges.createStub();
+    private String traceId;
+
+    private HttpHandler handler;
+
+    @Before
+    public void before() {
+        Tracer.subscribe("TEST_OBSERVER", observer);
+        Tracer.setSampler(traceSampler);
+
+        MDC.clear();
+
+        exchange.setRequestMethod(HttpString.tryFromString("GET"));
+        when(traceSampler.sample()).thenReturn(true);
+
+        traceId = Tracers.randomId();
+        handler = new TracedStateHandler(delegate);
+    }
+
+    @After
+    public void after() {
+        Tracer.unsubscribe("TEST_OBSERVER");
+    }
+
+    @Test
+    public void whenNoTraceIsInHeader_generatesNewTrace() throws Exception {
+        handler.handleRequest(exchange);
+
+        assertThat(Tracer.hasTraceId()).isFalse();
+        HeaderMap responseHeaders = exchange.getResponseHeaders();
+        assertThat(responseHeaders.get(TraceHttpHeaders.PARENT_SPAN_ID)).isNull();
+        assertThat(responseHeaders.get(TraceHttpHeaders.SPAN_ID)).isNull();
+        assertThat(responseHeaders.get(HttpString.tryFromString(TraceHttpHeaders.TRACE_ID)))
+                .isNotEmpty();
+    }
+
+    @Test
+    public void whenTraceIsInHeader_usesGivenTraceId() throws Exception {
+        setRequestTraceId(traceId);
+        handler.handleRequest(exchange);
+        assertThat(exchange.getResponseHeaders().getFirst(TraceHttpHeaders.TRACE_ID))
+                .isEqualTo(traceId);
+    }
+
+    @Test
+    public void whenParentSpanIsGiven_usesParentSpan() throws Exception {
+        setRequestTraceId(traceId);
+        String parentSpanId = Tracers.randomId();
+        setRequestSpanId(parentSpanId);
+
+        handler.handleRequest(exchange);
+        // Since we're not running a full request, the completion handler cannot execute normally.
+        exchange.getAttachment(UndertowTracing.REQUEST_SPAN).complete();
+        verify(observer, times(1)).consume(spanCaptor.capture());
+        List<Span> spans = spanCaptor.getAllValues();
+        assertThat(spans).hasSize(1);
+        Span span = spans.get(0);
+        assertThat(span.getParentSpanId()).hasValue(parentSpanId);
+        assertThat(span.getSpanId()).isNotEqualTo(parentSpanId);
+    }
+
+    @Test
+    public void whenParentSpanIsGiven_usesParentSpan_unsampled() throws Exception {
+        when(traceSampler.sample()).thenReturn(false);
+        setRequestTraceId(traceId);
+        String parentSpanId = Tracers.randomId();
+        setRequestSpanId(parentSpanId);
+
+        AtomicReference<String> capturedParentSpanId = new AtomicReference<>();
+        doAnswer((Answer<Void>) _invocation -> {
+                    Tracer.maybeGetTraceMetadata()
+                            .flatMap(TraceMetadata::getOriginatingSpanId)
+                            .ifPresent(capturedParentSpanId::set);
+                    return null;
+                })
+                .when(delegate)
+                .handleRequest(any());
+
+        handler.handleRequest(exchange);
+
+        assertThat(capturedParentSpanId).hasValue(parentSpanId);
+    }
+
+    @Test
+    public void whenTraceIsAlreadySampled_doesNotCallSampler() throws Exception {
+        exchange.getRequestHeaders().put(HttpString.tryFromString(TraceHttpHeaders.IS_SAMPLED), "1");
+        handler.handleRequest(exchange);
+
+        exchange.getRequestHeaders().put(HttpString.tryFromString(TraceHttpHeaders.IS_SAMPLED), "0");
+        handler.handleRequest(exchange);
+
+        setRequestTraceId(traceId);
+        handler.handleRequest(exchange);
+
+        verify(traceSampler, never()).sample();
+    }
+
+    @Test
+    public void whenTraceIsAlreadySampled_setsAttachment() throws Exception {
+        exchange.getRequestHeaders().put(HttpString.tryFromString(TraceHttpHeaders.IS_SAMPLED), "1");
+        handler.handleRequest(exchange);
+
+        assertThat(exchange.getAttachment(TracingAttachments.IS_SAMPLED)).isTrue();
+    }
+
+    @Test
+    public void whenTraceIsAlreadyNotSampled_setsAttachment() throws Exception {
+        exchange.getRequestHeaders().put(HttpString.tryFromString(TraceHttpHeaders.IS_SAMPLED), "0");
+        handler.handleRequest(exchange);
+
+        assertThat(exchange.getAttachment(TracingAttachments.IS_SAMPLED)).isFalse();
+    }
+
+    @Test
+    public void whenSamplingDecisionHasNotBeenMade_callsSampler() throws Exception {
+        handler.handleRequest(exchange);
+        verify(traceSampler).sample();
+    }
+
+    @Test
+    public void completesSpanEvenIfDelegateThrows() throws Exception {
+        doThrow(new RuntimeException()).when(delegate).handleRequest(any());
+        try {
+            handler.handleRequest(exchange);
+        } catch (RuntimeException e) {
+            // expected
+        }
+        assertThat(Tracer.completeSpan()).isEmpty();
+    }
+
+    @Test
+    public void populatesSlf4jMdc() throws Exception {
+        setRequestTraceId(traceId);
+        AtomicReference<String> mdcTraceValue = new AtomicReference<>();
+        new TracedOperationHandler(_exc -> mdcTraceValue.set(MDC.get(Tracers.TRACE_ID_KEY)), "GET /traced")
+                .handleRequest(exchange);
+        assertThat(mdcTraceValue).hasValue(traceId);
+        // Value should be cleared when the handler returns
+        assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isNull();
+    }
+
+    private void setRequestTraceId(String theTraceId) {
+        exchange.getRequestHeaders().put(HttpString.tryFromString(TraceHttpHeaders.TRACE_ID), theTraceId);
+    }
+
+    private void setRequestSpanId(String spanId) {
+        exchange.getRequestHeaders().put(HttpString.tryFromString(TraceHttpHeaders.SPAN_ID), spanId);
+    }
+}

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -417,13 +417,11 @@ public final class Tracer {
         @MustBeClosed
         public <T> CloseableSpan childSpan(
                 String operationName, TagTranslator<? super T> translator, T data, SpanType type) {
-            warnIfCompleted("startSpanOnCurrentThread");
             return childSpan(traceId, openSpan, requestId, operationName, translator, data, type);
         }
 
         @Override
         public DetachedSpan childDetachedSpan(String operation, SpanType type) {
-            warnIfCompleted("startDetachedSpan");
             return new SampledDetachedSpan(operation, type, traceId, requestId, Optional.of(openSpan.getSpanId()));
         }
 
@@ -444,7 +442,6 @@ public final class Tracer {
         @Override
         @MustBeClosed
         public CloseableSpan attach() {
-            warnIfCompleted("startSpanOnCurrentThread");
             return attach(traceId, openSpan, requestId);
         }
 
@@ -473,15 +470,6 @@ public final class Tracer {
                     + ", openSpan="
                     + openSpan
                     + '}';
-        }
-
-        private void warnIfCompleted(String feature) {
-            if (completed == COMPLETE) {
-                log.warn(
-                        "{} called after span {} completed",
-                        SafeArg.of("feature", feature),
-                        SafeArg.of("detachedSpan", this));
-            }
         }
     }
 


### PR DESCRIPTION
This allows us to remove a largely redundant tracing span and flatten
our graphs very slightly.

Note that the sampled span warn-if-completed logging has been
removed. I think adding it originally was a mistake given
the probabilistic nature. There are many scenarios in which
a server exchange may end prior to code execution (for example
when clients disconnect) where we would expect to see these
warnings.

==COMMIT_MSG==
Allow conjure-undertow to leverage the `DetachedSpan.attach()` mechanism without creating spans for blocking work
==COMMIT_MSG==

## Possible downsides?
When clients disconnect
before the server finishes processing blocking work, the spans
may provide somewhat less information. This is an edge case,
and I don't believe it's worth the additional spans, but is worth
describing here.
