### PR TITLE
Remove unused headers: `X-B3-ParentSpanId` and `X-OrigSpanId`

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -38,3 +38,22 @@ acceptedBreaks:
     - code: "java.method.addedToInterface"
       new: "method com.palantir.tracing.CloseableSpan com.palantir.tracing.DetachedSpan::attach()"
       justification: "DetachedSpan is not meant for external implementations"
+  "6.3.0":
+    com.palantir.tracing:tracing:
+    - code: "java.method.removed"
+      old: "method com.palantir.tracing.TraceMetadata.Builder com.palantir.tracing.ImmutableTraceMetadata.Builder::originatingSpanId(java.lang.String)\
+        \ @ com.palantir.tracing.TraceMetadata.Builder"
+      justification: "Type is not meant for external creation"
+    - code: "java.method.removed"
+      old: "method com.palantir.tracing.TraceMetadata.Builder com.palantir.tracing.ImmutableTraceMetadata.Builder::originatingSpanId(java.util.Optional<java.lang.String>)\
+        \ @ com.palantir.tracing.TraceMetadata.Builder"
+      justification: "Type is not meant for external creation"
+    com.palantir.tracing:tracing-api:
+    - code: "java.method.removed"
+      old: "method com.palantir.tracing.api.OpenSpan.Builder com.palantir.tracing.api.ImmutableOpenSpan.Builder::originatingSpanId(java.lang.String)\
+        \ @ com.palantir.tracing.api.OpenSpan.Builder"
+      justification: "Type is not meant for external creation"
+    - code: "java.method.removed"
+      old: "method com.palantir.tracing.api.OpenSpan.Builder com.palantir.tracing.api.ImmutableOpenSpan.Builder::originatingSpanId(java.util.Optional<java.lang.String>)\
+        \ @ com.palantir.tracing.api.OpenSpan.Builder"
+      justification: "Type is not meant for external creation"

--- a/changelog/@unreleased/pr-778.v2.yml
+++ b/changelog/@unreleased/pr-778.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'Remove unused headers: `X-B3-ParentSpanId` and `X-OrigSpanId`'
+  links:
+  - https://github.com/palantir/tracing-java/pull/778

--- a/tracing-api/src/main/java/com/palantir/tracing/api/OpenSpan.java
+++ b/tracing-api/src/main/java/com/palantir/tracing/api/OpenSpan.java
@@ -59,10 +59,14 @@ public abstract class OpenSpan {
     /**
      * Returns the identifier of the 'originating' span if one exists.
      *
-     * @see TraceHttpHeaders
+     * @see TraceHttpHeaders#ORIGINATING_SPAN_ID
+     * @deprecated No longer used.
      */
-    @Value.Parameter
-    public abstract Optional<String> getOriginatingSpanId();
+    @Deprecated
+    // Intentionally does not set @Value.Default because the value is always empty.
+    public Optional<String> getOriginatingSpanId() {
+        return Optional.empty();
+    }
 
     /** Returns a globally unique identifier representing a single span within the call trace. */
     @Value.Parameter
@@ -83,26 +87,25 @@ public abstract class OpenSpan {
         return new Builder().startTimeMicroSeconds(getNowInMicroSeconds()).startClockNanoSeconds(System.nanoTime());
     }
 
-    /** Use this factory method to avoid allocate {@link Builder} in hot path. */
+    /**
+     * Use this factory method to avoid {@link Builder} allocations in hot paths.
+     *
+     * @deprecated Use the variant without an originating span id
+     */
+    @SuppressWarnings("InlineMeSuggester")
+    @Deprecated
     public static OpenSpan of(
             String operation,
             String spanId,
             SpanType type,
             Optional<String> parentSpanId,
-            Optional<String> originatingSpanId) {
-        return ImmutableOpenSpan.of(
-                operation, getNowInMicroSeconds(), System.nanoTime(), parentSpanId, originatingSpanId, spanId, type);
+            Optional<String> _originatingSpanId) {
+        return ImmutableOpenSpan.of(operation, getNowInMicroSeconds(), System.nanoTime(), parentSpanId, spanId, type);
     }
 
-    /**
-     * Deprecated.
-     *
-     * @deprecated Use the variant that accepts an originating span id
-     */
-    @SuppressWarnings("InlineMeSuggester")
-    @Deprecated
+    /** Use this factory method to avoid {@link Builder} allocations in hot paths. */
     public static OpenSpan of(String operation, String spanId, SpanType type, Optional<String> parentSpanId) {
-        return of(operation, spanId, type, parentSpanId, Optional.empty());
+        return ImmutableOpenSpan.of(operation, getNowInMicroSeconds(), System.nanoTime(), parentSpanId, spanId, type);
     }
 
     private static long getNowInMicroSeconds() {

--- a/tracing-api/src/main/java/com/palantir/tracing/api/TraceHttpHeaders.java
+++ b/tracing-api/src/main/java/com/palantir/tracing/api/TraceHttpHeaders.java
@@ -19,19 +19,22 @@ package com.palantir.tracing.api;
 /** Zipkin-compatible HTTP header names. */
 public interface TraceHttpHeaders {
     String TRACE_ID = "X-B3-TraceId";
+    /**
+     * Field is no longer used by the tracing library.
+     *
+     * @deprecated No longer used
+     */
+    @Deprecated
     String PARENT_SPAN_ID = "X-B3-ParentSpanId";
+
     String SPAN_ID = "X-B3-SpanId";
     String IS_SAMPLED = "X-B3-Sampled"; // Boolean (either “1” or “0”, can be absent)
 
     /**
-     * Conceptually, a trace is a stack of spans. In implementation, this is actually many stacks, in many servers,
-     * where a server's stack will typically contain a single parent span from a different server at the bottom, and
-     * many spans of its own above it.
+     * Field is no longer used by the tracing library.
      *
-     * <p>By communicating this deepest span id with future network calls as an 'originating' span id, this enables
-     * network-level tracing to be enabled always in a low-fidelity form, with request logs containing enough
-     * information to reconstruct a request-level trace, even when the trace is not sampled. For server-internal
-     * tracing, the typical trace logs (with sampling) are still required.
+     * @deprecated No longer used
      */
+    @Deprecated
     String ORIGINATING_SPAN_ID = "X-OrigSpanId";
 }

--- a/tracing-jersey/src/test/java/com/palantir/tracing/jersey/TraceEnrichingFilterTest.java
+++ b/tracing-jersey/src/test/java/com/palantir/tracing/jersey/TraceEnrichingFilterTest.java
@@ -112,11 +112,9 @@ public final class TraceEnrichingFilterTest {
         Response response = target.path("/trace")
                 .request()
                 .header(TraceHttpHeaders.TRACE_ID, "traceId")
-                .header(TraceHttpHeaders.PARENT_SPAN_ID, "parentSpanId")
                 .header(TraceHttpHeaders.SPAN_ID, "spanId")
                 .get();
         assertThat(response.getHeaderString(TraceHttpHeaders.TRACE_ID)).isEqualTo("traceId");
-        assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID)).isNull();
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID)).isNull();
         verify(observer).consume(spanCaptor.capture());
         assertThat(spanCaptor.getValue().getOperation()).isEqualTo("Jersey: GET /trace");
@@ -127,11 +125,9 @@ public final class TraceEnrichingFilterTest {
         Response response = target.path("/trace")
                 .request()
                 .header(TraceHttpHeaders.TRACE_ID, "traceId")
-                .header(TraceHttpHeaders.PARENT_SPAN_ID, "parentSpanId")
                 .header(TraceHttpHeaders.SPAN_ID, "spanId")
                 .post(Entity.json(""));
         assertThat(response.getHeaderString(TraceHttpHeaders.TRACE_ID)).isEqualTo("traceId");
-        assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID)).isNull();
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID)).isNull();
         verify(observer).consume(spanCaptor.capture());
         assertThat(spanCaptor.getValue().getOperation()).isEqualTo("Jersey: POST /trace");
@@ -142,11 +138,9 @@ public final class TraceEnrichingFilterTest {
         Response response = target.path("/trace/no")
                 .request()
                 .header(TraceHttpHeaders.TRACE_ID, "traceId")
-                .header(TraceHttpHeaders.PARENT_SPAN_ID, "parentSpanId")
                 .header(TraceHttpHeaders.SPAN_ID, "spanId")
                 .get();
         assertThat(response.getHeaderString(TraceHttpHeaders.TRACE_ID)).isEqualTo("traceId");
-        assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID)).isNull();
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID)).isNull();
         verify(observer).consume(spanCaptor.capture());
         assertThat(spanCaptor.getValue().getOperation()).isEqualTo("Jersey: GET /trace/{param}");
@@ -156,7 +150,6 @@ public final class TraceEnrichingFilterTest {
     public void testTraceState_withoutRequestHeadersGeneratesValidTraceResponseHeaders() {
         Response response = target.path("/trace").request().get();
         assertThat(response.getHeaderString(TraceHttpHeaders.TRACE_ID)).isNotNull();
-        assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID)).isNull();
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID)).isNull();
         verify(observer).consume(spanCaptor.capture());
         Span span = spanCaptor.getValue();
@@ -169,7 +162,6 @@ public final class TraceEnrichingFilterTest {
     public void testTraceState_setsResponseStatus() {
         Response response = target.path("/trace").request().post(null);
         assertThat(response.getHeaderString(TraceHttpHeaders.TRACE_ID)).isNotNull();
-        assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID)).isNull();
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID)).isNull();
         verify(observer).consume(spanCaptor.capture());
         Span span = spanCaptor.getValue();
@@ -185,7 +177,6 @@ public final class TraceEnrichingFilterTest {
     public void testTraceState_withoutRequestHeadersGeneratesValidTraceResponseHeadersWhenFailing() {
         Response response = target.path("/failing-trace").request().get();
         assertThat(response.getHeaderString(TraceHttpHeaders.TRACE_ID)).isNotNull();
-        assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID)).isNull();
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID)).isNull();
         verify(observer).consume(spanCaptor.capture());
         Span span = spanCaptor.getValue();
@@ -198,7 +189,6 @@ public final class TraceEnrichingFilterTest {
     public void testTraceState_withoutRequestHeadersGeneratesValidTraceResponseHeadersWhenStreaming() {
         Response response = target.path("/streaming-trace").request().get();
         assertThat(response.getHeaderString(TraceHttpHeaders.TRACE_ID)).isNotNull();
-        assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID)).isNull();
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID)).isNull();
         verify(observer).consume(spanCaptor.capture());
         assertThat(spanCaptor.getValue().getOperation()).isEqualTo("Jersey: GET /streaming-trace");
@@ -208,7 +198,6 @@ public final class TraceEnrichingFilterTest {
     public void testTraceState_withoutRequestHeadersGeneratesValidTraceResponseHeadersWhenFailingToStream() {
         Response response = target.path("/failing-streaming-trace").request().get();
         assertThat(response.getHeaderString(TraceHttpHeaders.TRACE_ID)).isNotNull();
-        assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID)).isNull();
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID)).isNull();
         verify(observer).consume(spanCaptor.capture());
         assertThat(spanCaptor.getValue().getOperation()).isEqualTo("Jersey: GET /failing-streaming-trace");
@@ -233,7 +222,6 @@ public final class TraceEnrichingFilterTest {
                 .header(TraceHttpHeaders.TRACE_ID, "")
                 .get();
         assertThat(response.getHeaderString(TraceHttpHeaders.TRACE_ID)).isNotNull();
-        assertThat(response.getHeaderString(TraceHttpHeaders.PARENT_SPAN_ID)).isNull();
         assertThat(response.getHeaderString(TraceHttpHeaders.SPAN_ID)).isNull();
         verify(observer).consume(spanCaptor.capture());
         assertThat(spanCaptor.getValue().getOperation()).isEqualTo("Jersey: GET /trace");

--- a/tracing-okhttp3/src/main/java/com/palantir/tracing/OkhttpTraceInterceptor2.java
+++ b/tracing-okhttp3/src/main/java/com/palantir/tracing/OkhttpTraceInterceptor2.java
@@ -47,24 +47,11 @@ public final class OkhttpTraceInterceptor2 implements Interceptor {
             TraceMetadata metadata = Tracer.maybeGetTraceMetadata()
                     .orElseThrow(() -> new SafeRuntimeException("Trace with no spans in progress"));
 
-            Request.Builder tracedRequest = request.newBuilder()
+            return chain.proceed(request.newBuilder()
                     .header(TraceHttpHeaders.TRACE_ID, Tracer.getTraceId())
                     .header(TraceHttpHeaders.SPAN_ID, metadata.getSpanId())
-                    .header(TraceHttpHeaders.IS_SAMPLED, Tracer.isTraceObservable() ? "1" : "0");
-
-            if (metadata.getParentSpanId().isPresent()) {
-                tracedRequest.header(
-                        TraceHttpHeaders.PARENT_SPAN_ID,
-                        metadata.getParentSpanId().get());
-            }
-
-            if (metadata.getOriginatingSpanId().isPresent()) {
-                tracedRequest.header(
-                        TraceHttpHeaders.ORIGINATING_SPAN_ID,
-                        metadata.getOriginatingSpanId().get());
-            }
-
-            return chain.proceed(tracedRequest.build());
+                    .header(TraceHttpHeaders.IS_SAMPLED, Tracer.isTraceObservable() ? "1" : "0")
+                    .build());
         }
     }
 }

--- a/tracing-okhttp3/src/main/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptor.java
+++ b/tracing-okhttp3/src/main/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptor.java
@@ -53,15 +53,6 @@ public enum OkhttpTraceInterceptor implements Interceptor {
                 .header(TraceHttpHeaders.TRACE_ID, Tracer.getTraceId())
                 .header(TraceHttpHeaders.SPAN_ID, span.getSpanId())
                 .header(TraceHttpHeaders.IS_SAMPLED, Tracer.isTraceObservable() ? "1" : "0");
-        if (span.getParentSpanId().isPresent()) {
-            tracedRequest.header(
-                    TraceHttpHeaders.PARENT_SPAN_ID, span.getParentSpanId().get());
-        }
-        if (span.getOriginatingSpanId().isPresent()) {
-            tracedRequest.header(
-                    TraceHttpHeaders.ORIGINATING_SPAN_ID,
-                    span.getOriginatingSpanId().get());
-        }
 
         Response response;
         try {

--- a/tracing-okhttp3/src/test/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptorTest.java
+++ b/tracing-okhttp3/src/test/java/com/palantir/tracing/okhttp3/OkhttpTraceInterceptorTest.java
@@ -82,8 +82,6 @@ public final class OkhttpTraceInterceptorTest {
         Request intercepted = requestCaptor.getValue();
         assertThat(intercepted.headers(TraceHttpHeaders.SPAN_ID)).hasSize(1);
         assertThat(intercepted.headers(TraceHttpHeaders.TRACE_ID)).hasSize(1);
-        assertThat(intercepted.headers(TraceHttpHeaders.ORIGINATING_SPAN_ID)).isEmpty();
-        assertThat(intercepted.headers(TraceHttpHeaders.PARENT_SPAN_ID)).isEmpty();
     }
 
     @Test
@@ -104,7 +102,6 @@ public final class OkhttpTraceInterceptorTest {
         Request intercepted = requestCaptor.getValue();
         assertThat(intercepted.headers(TraceHttpHeaders.SPAN_ID)).isNotNull();
         assertThat(intercepted.headers(TraceHttpHeaders.TRACE_ID)).containsOnly(traceId);
-        assertThat(intercepted.headers(TraceHttpHeaders.ORIGINATING_SPAN_ID)).containsOnly(originatingSpanId);
     }
 
     @Test

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -63,12 +63,7 @@ public abstract class Trace {
     final OpenSpan startSpan(String operation, String parentSpanId, SpanType type) {
         checkState(isEmpty(), "Cannot start a span with explicit parent if the current thread's trace is non-empty");
         checkArgument(!Strings.isNullOrEmpty(parentSpanId), "parentSpanId must be non-empty");
-        OpenSpan span = OpenSpan.of(
-                operation,
-                Tracers.randomId(),
-                type,
-                Optional.of(parentSpanId),
-                orElse(getOriginatingSpanId(), Optional.of(parentSpanId)));
+        OpenSpan span = OpenSpan.of(operation, Tracers.randomId(), type, Optional.of(parentSpanId));
         push(span);
         return span;
     }
@@ -87,21 +82,13 @@ public abstract class Trace {
                     operation,
                     Tracers.randomId(),
                     type,
-                    Optional.of(prevState.get().getSpanId()),
-                    orElse(getOriginatingSpanId(), prevState.get().getParentSpanId()));
+                    Optional.of(prevState.get().getSpanId()));
         } else {
-            span = OpenSpan.of(operation, Tracers.randomId(), type, Optional.empty(), getOriginatingSpanId());
+            span = OpenSpan.of(operation, Tracers.randomId(), type, Optional.empty());
         }
 
         push(span);
         return span;
-    }
-
-    private static <T> Optional<T> orElse(Optional<T> left, Optional<T> right) {
-        if (left.isPresent()) {
-            return left;
-        }
-        return right;
     }
 
     /** Like {@link #startSpan(String, String, SpanType)}, but does not return an {@link OpenSpan}. */
@@ -139,8 +126,6 @@ public abstract class Trace {
     final Optional<String> getRequestId() {
         return requestId;
     }
-
-    abstract Optional<String> getOriginatingSpanId();
 
     /** Returns a copy of this Trace which can be independently mutated. */
     abstract Trace deepCopy();
@@ -200,14 +185,6 @@ public abstract class Trace {
         }
 
         @Override
-        Optional<String> getOriginatingSpanId() {
-            if (stack.isEmpty()) {
-                return Optional.empty();
-            }
-            return stack.peekLast().getParentSpanId();
-        }
-
-        @Override
         Trace deepCopy() {
             return new Sampled(new ArrayDeque<>(stack), getTraceId(), getRequestId());
         }
@@ -225,8 +202,6 @@ public abstract class Trace {
          */
         private int numberOfSpans;
 
-        private Optional<String> originatingSpanId = Optional.empty();
-
         private Unsampled(int numberOfSpans, String traceId, Optional<String> requestId) {
             super(traceId, requestId);
             this.numberOfSpans = numberOfSpans;
@@ -238,8 +213,8 @@ public abstract class Trace {
         }
 
         @Override
-        void fastStartSpan(String _operation, String parentSpanId, SpanType _type) {
-            startSpan(Optional.of(parentSpanId));
+        void fastStartSpan(String _operation, String _parentSpanId, SpanType _type) {
+            numberOfSpans++;
         }
 
         @Override
@@ -248,14 +223,7 @@ public abstract class Trace {
         }
 
         @Override
-        protected void push(OpenSpan span) {
-            startSpan(span.getParentSpanId());
-        }
-
-        private void startSpan(Optional<String> parentSpanId) {
-            if (numberOfSpans == 0) {
-                originatingSpanId = parentSpanId;
-            }
+        protected void push(OpenSpan _span) {
             numberOfSpans++;
         }
 
@@ -270,9 +238,6 @@ public abstract class Trace {
             if (numberOfSpans > 0) {
                 numberOfSpans--;
             }
-            if (numberOfSpans == 0) {
-                originatingSpanId = Optional.empty();
-            }
             return Optional.empty();
         }
 
@@ -285,11 +250,6 @@ public abstract class Trace {
         @Override
         boolean isObservable() {
             return false;
-        }
-
-        @Override
-        Optional<String> getOriginatingSpanId() {
-            return originatingSpanId;
         }
 
         @Override

--- a/tracing/src/main/java/com/palantir/tracing/TraceMetadata.java
+++ b/tracing/src/main/java/com/palantir/tracing/TraceMetadata.java
@@ -33,14 +33,22 @@ public interface TraceMetadata {
      */
     Optional<String> getRequestId();
 
-    /** Corresponds to {@link com.palantir.tracing.api.TraceHttpHeaders#SPAN_ID}. */
+    /** Corresponds to {@link com.palantir.tracing.api.TraceHttpHeaders#SPAN_ID} on outgoing requests. */
     String getSpanId();
 
-    /** Corresponds to {@link com.palantir.tracing.api.TraceHttpHeaders#PARENT_SPAN_ID}. */
+    /** Corresponds to {@link com.palantir.tracing.api.TraceHttpHeaders#SPAN_ID} on incoming requests. */
     Optional<String> getParentSpanId();
 
-    /** Corresponds to {@link com.palantir.tracing.api.TraceHttpHeaders#ORIGINATING_SPAN_ID}. */
-    Optional<String> getOriginatingSpanId();
+    /**
+     * Corresponds to {@link com.palantir.tracing.api.TraceHttpHeaders#ORIGINATING_SPAN_ID} which is no longer used.
+     *
+     * @deprecated No longer used
+     */
+    @Deprecated
+    // Intentionally does not set @Value.Default because the value is always empty.
+    default Optional<String> getOriginatingSpanId() {
+        return Optional.empty();
+    }
 
     static Builder builder() {
         return new Builder();

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -117,7 +117,6 @@ public final class Tracer {
             return trace.top().map(openSpan -> TraceMetadata.builder()
                     .spanId(openSpan.getSpanId())
                     .parentSpanId(openSpan.getParentSpanId())
-                    .originatingSpanId(trace.getOriginatingSpanId())
                     .traceId(trace.getTraceId())
                     .requestId(trace.getRequestId())
                     .build());
@@ -125,7 +124,6 @@ public final class Tracer {
             return Optional.of(TraceMetadata.builder()
                     .spanId(Tracers.randomId())
                     .parentSpanId(Optional.empty())
-                    .originatingSpanId(trace.getOriginatingSpanId())
                     .traceId(trace.getTraceId())
                     .requestId(trace.getRequestId())
                     .build());
@@ -390,12 +388,7 @@ public final class Tracer {
                 Optional<String> parentSpanId) {
             this.traceId = traceId;
             this.requestId = requestId;
-            this.openSpan = OpenSpan.builder()
-                    .parentSpanId(parentSpanId)
-                    .spanId(Tracers.randomId())
-                    .operation(operation)
-                    .type(type)
-                    .build();
+            this.openSpan = OpenSpan.of(operation, Tracers.randomId(), type, parentSpanId);
         }
 
         @MustBeClosed

--- a/tracing/src/test/java/com/palantir/tracing/TraceTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TraceTest.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import org.junit.Test;
 
 public final class TraceTest {
-    private static final String ORIGINATING_SPAN_ID = "originating span id";
 
     @Test
     public void constructTrace_emptyTraceId() {
@@ -40,39 +39,5 @@ public final class TraceTest {
                 .isEqualTo("Trace{stack=[" + span + "], isObservable=true, traceId='traceId'}")
                 .contains(span.getOperation())
                 .contains(span.getSpanId());
-    }
-
-    @Test
-    public void testOriginatingTraceId_slow_sampled() {
-        Trace trace = Trace.of(true, "traceId", Optional.empty());
-        OpenSpan originating = trace.startSpan("1", ORIGINATING_SPAN_ID, SpanType.LOCAL);
-        assertThat(originating.getOriginatingSpanId()).contains(ORIGINATING_SPAN_ID);
-        OpenSpan span = trace.startSpan("2", SpanType.LOCAL);
-        assertThat(span.getOriginatingSpanId()).contains(ORIGINATING_SPAN_ID);
-    }
-
-    @Test
-    public void testOriginatingTraceId_fast_sampled() {
-        Trace trace = Trace.of(true, "traceId", Optional.empty());
-        trace.fastStartSpan("1", ORIGINATING_SPAN_ID, SpanType.LOCAL);
-        OpenSpan span = trace.startSpan("2", SpanType.LOCAL);
-        assertThat(span.getOriginatingSpanId()).contains(ORIGINATING_SPAN_ID);
-    }
-
-    @Test
-    public void testOriginatingTraceId_slow_unsampled() {
-        Trace trace = Trace.of(false, "traceId", Optional.empty());
-        OpenSpan originating = trace.startSpan("1", ORIGINATING_SPAN_ID, SpanType.LOCAL);
-        assertThat(originating.getOriginatingSpanId()).contains(ORIGINATING_SPAN_ID);
-        OpenSpan span = trace.startSpan("2", SpanType.LOCAL);
-        assertThat(span.getOriginatingSpanId()).contains(ORIGINATING_SPAN_ID);
-    }
-
-    @Test
-    public void testOriginatingTraceId_fast_unsampled() {
-        Trace trace = Trace.of(false, "traceId", Optional.empty());
-        trace.fastStartSpan("1", ORIGINATING_SPAN_ID, SpanType.LOCAL);
-        OpenSpan span = trace.startSpan("2", SpanType.LOCAL);
-        assertThat(span.getOriginatingSpanId()).contains(ORIGINATING_SPAN_ID);
     }
 }


### PR DESCRIPTION
`X-B3-ParentSpanId` isn't standard zipkin, and doesn't provide
any data we don't already have. The parent span of an incoming
request span is the value of the `X-B3-SpanId` header. There's
no reason for additional header values.

`X-OrigSpanId` is a custom header added to provide some amount of
tracing functionality when traces aren't sampled, however it
hasn't quite worked and isn't supported by alternative tracing
engines.

==COMMIT_MSG==
Remove unused headers: `X-B3-ParentSpanId` and `X-OrigSpanId`
==COMMIT_MSG==

