### PR TITLE
Common trace state for tracing

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -57,3 +57,9 @@ acceptedBreaks:
       old: "method com.palantir.tracing.api.OpenSpan.Builder com.palantir.tracing.api.ImmutableOpenSpan.Builder::originatingSpanId(java.util.Optional<java.lang.String>)\
         \ @ com.palantir.tracing.api.OpenSpan.Builder"
       justification: "Type is not meant for external creation"
+  "6.4.0":
+    com.palantir.tracing:tracing:
+    - code: "java.field.serialVersionUIDChanged"
+      old: "field com.palantir.tracing.DeferredTracer.serialVersionUID"
+      new: "field com.palantir.tracing.DeferredTracer.serialVersionUID"
+      justification: "Library versions are in usually in sync"

--- a/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
+++ b/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
@@ -22,22 +22,27 @@ import static com.palantir.logsafe.Preconditions.checkNotNull;
 import com.google.common.base.Strings;
 import java.io.Serializable;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * Class representing the state which is created for each {@link Trace}. Contains the globally non-unique identifier of
  * a trace and a request identifier used to identify different requests sent from the same trace.
  */
 final class CommonTraceState implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private final String traceId;
-    private final Optional<String> requestId;
+
+    @Nullable
+    private final String requestId;
 
     static CommonTraceState create(String traceId, Optional<String> requestId) {
         checkArgument(!Strings.isNullOrEmpty(traceId), "traceId must be non-empty");
         checkNotNull(requestId, "requestId should be not-null");
-        return new CommonTraceState(traceId, requestId);
+        return new CommonTraceState(traceId, requestId.orElse(null));
     }
 
-    private CommonTraceState(String traceId, Optional<String> requestId) {
+    private CommonTraceState(String traceId, String requestId) {
         this.traceId = traceId;
         this.requestId = requestId;
     }
@@ -57,7 +62,7 @@ final class CommonTraceState implements Serializable {
      * distinguish between requests with the same traceId.
      */
     Optional<String> getRequestId() {
-        return requestId;
+        return Optional.ofNullable(requestId);
     }
 
     CommonTraceState deepCopy() {
@@ -66,6 +71,6 @@ final class CommonTraceState implements Serializable {
 
     @Override
     public String toString() {
-        return "CommonTraceState{" + "traceId='" + traceId + '\'' + ", requestId=" + requestId.orElse(null) + '}';
+        return "CommonTraceState{" + "traceId='" + traceId + '\'' + ", requestId=" + requestId + '}';
     }
 }

--- a/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
+++ b/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
@@ -61,7 +61,8 @@ final class CommonTraceState implements Serializable {
      * each time a new trace is created with a SERVER_INCOMING root span. This is a convenience in order to
      * distinguish between requests with the same traceId.
      */
-    Optional<String> getRequestId() {
+    @Nullable
+    String getRequestId() {
         return Optional.ofNullable(requestId);
     }
 

--- a/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
+++ b/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
@@ -22,11 +22,15 @@ import static com.palantir.logsafe.Preconditions.checkNotNull;
 import com.google.common.base.Strings;
 import java.util.Optional;
 
-public final class CommonTraceState {
+/**
+ * Class representing the state which is created for each {@link Trace}. Contains the globally non-unique identifier of
+ * a trace and a request identifier used to identify different requests sent from the same trace.
+ */
+final class CommonTraceState {
     private final String traceId;
     private final Optional<String> requestId;
 
-    public static CommonTraceState create(String traceId, Optional<String> requestId) {
+    static CommonTraceState create(String traceId, Optional<String> requestId) {
         checkArgument(!Strings.isNullOrEmpty(traceId), "traceId must be non-empty");
         checkNotNull(requestId, "requestId should be not-null");
         return new CommonTraceState(traceId, requestId);
@@ -37,11 +41,30 @@ public final class CommonTraceState {
         this.requestId = requestId;
     }
 
-    public String getTraceId() {
+    /**
+     * The globally unique non-empty identifier for this call trace.
+     * */
+    String getTraceId() {
         return traceId;
     }
 
-    public Optional<String> getRequestId() {
+    /**
+     * The request identifier of this trace.
+     *
+     * The request identifier is an implementation detail of this tracing library. A new identifier is generated
+     * each time a new trace is created with a SERVER_INCOMING root span. This is a convenience in order to
+     * distinguish between requests with the same traceId.
+     */
+    Optional<String> getRequestId() {
         return requestId;
+    }
+
+    CommonTraceState deepCopy() {
+        return new CommonTraceState(traceId, requestId);
+    }
+
+    @Override
+    public String toString() {
+        return "CommonTraceState{" + "traceId='" + traceId + '\'' + ", requestId=" + requestId.orElse(null) + '}';
     }
 }

--- a/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
+++ b/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
@@ -71,6 +71,6 @@ final class CommonTraceState implements Serializable {
 
     @Override
     public String toString() {
-        return "CommonTraceState{" + "traceId='" + traceId + '\'' + ", requestId=" + requestId + '}';
+        return "CommonTraceState{traceId='" + traceId + "', requestId=" + requestId + '}';
     }
 }

--- a/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
+++ b/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
@@ -20,13 +20,14 @@ import static com.palantir.logsafe.Preconditions.checkArgument;
 import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.google.common.base.Strings;
+import java.io.Serializable;
 import java.util.Optional;
 
 /**
  * Class representing the state which is created for each {@link Trace}. Contains the globally non-unique identifier of
  * a trace and a request identifier used to identify different requests sent from the same trace.
  */
-final class CommonTraceState {
+final class CommonTraceState implements Serializable {
     private final String traceId;
     private final Optional<String> requestId;
 

--- a/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
+++ b/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
@@ -1,0 +1,47 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tracing;
+
+import static com.palantir.logsafe.Preconditions.checkArgument;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
+
+import com.google.common.base.Strings;
+import java.util.Optional;
+
+public final class CommonTraceState {
+    private final String traceId;
+    private final Optional<String> requestId;
+
+    public static CommonTraceState create(String traceId, Optional<String> requestId) {
+        checkArgument(!Strings.isNullOrEmpty(traceId), "traceId must be non-empty");
+        checkNotNull(requestId, "requestId should be not-null");
+        return new CommonTraceState(traceId, requestId);
+    }
+
+    private CommonTraceState(String traceId, Optional<String> requestId) {
+        this.traceId = traceId;
+        this.requestId = requestId;
+    }
+
+    public String getTraceId() {
+        return traceId;
+    }
+
+    public Optional<String> getRequestId() {
+        return requestId;
+    }
+}

--- a/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
+++ b/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
@@ -36,7 +36,7 @@ final class CommonTraceState implements Serializable {
     @Nullable
     private final String requestId;
 
-    static CommonTraceState create(String traceId, Optional<String> requestId) {
+    static CommonTraceState of(String traceId, Optional<String> requestId) {
         checkArgument(!Strings.isNullOrEmpty(traceId), "traceId must be non-empty");
         checkNotNull(requestId, "requestId should be not-null");
         return new CommonTraceState(traceId, requestId.orElse(null));

--- a/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
+++ b/tracing/src/main/java/com/palantir/tracing/CommonTraceState.java
@@ -42,7 +42,7 @@ final class CommonTraceState implements Serializable {
         return new CommonTraceState(traceId, requestId.orElse(null));
     }
 
-    private CommonTraceState(String traceId, String requestId) {
+    private CommonTraceState(String traceId, @Nullable String requestId) {
         this.traceId = traceId;
         this.requestId = requestId;
     }

--- a/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
@@ -58,7 +58,7 @@ public final class DeferredTracer implements Serializable {
     private static final String DEFAULT_OPERATION = "DeferredTracer(unnamed operation)";
 
     @Nullable
-    private final String traceId;
+    private final CommonTraceState commonTraceState;
 
     private final boolean isObservable;
 
@@ -70,9 +70,6 @@ public final class DeferredTracer implements Serializable {
 
     @Nullable
     private final String parentSpanId;
-
-    @Nullable
-    private final transient String requestId;
 
     /**
      * Deprecated.
@@ -98,15 +95,13 @@ public final class DeferredTracer implements Serializable {
         Optional<Trace> maybeTrace = Tracer.copyTrace();
         if (maybeTrace.isPresent()) {
             Trace trace = maybeTrace.get();
-            this.traceId = trace.getTraceId();
-            this.requestId = trace.getRequestId().orElse(null);
+            this.commonTraceState = trace.getCommonTraceState();
             this.isObservable = trace.isObservable();
             this.parentSpanId = trace.top().map(OpenSpan::getSpanId).orElse(null);
             this.operation = operation;
             this.metadata = metadata;
         } else {
-            this.traceId = null;
-            this.requestId = null;
+            this.commonTraceState = null;
             this.isObservable = false;
             this.parentSpanId = null;
             this.operation = null;
@@ -128,13 +123,13 @@ public final class DeferredTracer implements Serializable {
     @MustBeClosed
     @SuppressWarnings("NullAway") // either both operation & parentSpanId are nullable or neither are
     CloseableTrace withTrace() {
-        if (traceId == null) {
+        if (commonTraceState == null) {
             return NopCloseableTrace.INSTANCE;
         }
 
         Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
-        Tracer.setTrace(Trace.of(isObservable, traceId, Optional.ofNullable(requestId)));
+        Tracer.setTrace(Trace.of(isObservable, commonTraceState));
         if (parentSpanId != null) {
             Tracer.fastStartSpan(operation, parentSpanId, SpanType.LOCAL);
         } else {

--- a/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
@@ -53,12 +53,12 @@ import javax.annotation.Nullable;
  */
 public final class DeferredTracer implements Serializable {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     private static final String DEFAULT_OPERATION = "DeferredTracer(unnamed operation)";
 
     @Nullable
-    private final CommonTraceState commonTraceState;
+    private final TraceState traceState;
 
     private final boolean isObservable;
 
@@ -95,13 +95,13 @@ public final class DeferredTracer implements Serializable {
         Optional<Trace> maybeTrace = Tracer.copyTrace();
         if (maybeTrace.isPresent()) {
             Trace trace = maybeTrace.get();
-            this.commonTraceState = trace.getCommonTraceState();
+            this.traceState = trace.getTraceState();
             this.isObservable = trace.isObservable();
             this.parentSpanId = trace.top().map(OpenSpan::getSpanId).orElse(null);
             this.operation = operation;
             this.metadata = metadata;
         } else {
-            this.commonTraceState = null;
+            this.traceState = null;
             this.isObservable = false;
             this.parentSpanId = null;
             this.operation = null;
@@ -123,13 +123,13 @@ public final class DeferredTracer implements Serializable {
     @MustBeClosed
     @SuppressWarnings("NullAway") // either both operation & parentSpanId are nullable or neither are
     CloseableTrace withTrace() {
-        if (commonTraceState == null) {
+        if (traceState == null) {
             return NopCloseableTrace.INSTANCE;
         }
 
         Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
-        Tracer.setTrace(Trace.of(isObservable, commonTraceState));
+        Tracer.setTrace(Trace.of(isObservable, traceState));
         if (parentSpanId != null) {
             Tracer.fastStartSpan(operation, parentSpanId, SpanType.LOCAL);
         } else {

--- a/tracing/src/main/java/com/palantir/tracing/InternalTracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/InternalTracers.java
@@ -33,7 +33,7 @@ public final class InternalTracers {
 
     /** Returns true if the provided detachedSpan is sampled. */
     public static Optional<String> getRequestId(DetachedSpan detachedSpan) {
-        return Tracer.getRequestId(detachedSpan);
+        return Optional.ofNullable(Tracer.getRequestId(detachedSpan));
     }
 
     private InternalTracers() {}

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -202,7 +202,7 @@ public abstract class Trace {
 
         @Override
         public String toString() {
-            return "Trace{stack=" + stack + ", isObservable=true, state=" + getTraceState() + "'}";
+            return "Trace{stack=" + stack + ", isObservable=true, state=" + getTraceState() + "}";
         }
     }
 

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -108,16 +108,12 @@ public abstract class Trace {
      */
     abstract boolean isObservable();
 
-    /**
-     * The state of the trace which is stored for each created trace.
-     */
+    /** The state of the trace which is stored for each created trace. */
     final TraceState getTraceState() {
         return this.traceState;
     }
 
-    /**
-     * The globally unique non-empty identifier for this call trace.
-     * */
+    /** The globally unique non-empty identifier for this call trace. */
     final String getTraceId() {
         return traceState.traceId();
     }
@@ -128,7 +124,7 @@ public abstract class Trace {
      * The request identifier is an implementation detail of this tracing library. A new identifier is generated
      * each time a new trace is created with a SERVER_INCOMING root span. This is a convenience in order to
      * distinguish between requests with the same traceId.
-     * */
+     */
     final Optional<String> getRequestId() {
         return Optional.ofNullable(traceState.requestId());
     }

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -47,7 +47,7 @@ public abstract class Trace {
     private final TraceState traceState;
 
     private Trace(TraceState traceState) {
-        checkNotNull(traceState, "Common trace state should not be null");
+        checkNotNull(traceState, "Trace state must not be null");
         this.traceState = traceState;
     }
 

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -144,7 +144,7 @@ public abstract class Trace {
 
     @Deprecated
     static Trace of(boolean isObservable, String traceId, Optional<String> requestId) {
-        return of(isObservable, CommonTraceState.create(traceId, requestId));
+        return of(isObservable, CommonTraceState.of(traceId, requestId));
     }
 
     static Trace of(boolean isObservable, CommonTraceState commonTraceState) {

--- a/tracing/src/main/java/com/palantir/tracing/TraceState.java
+++ b/tracing/src/main/java/com/palantir/tracing/TraceState.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
  * Class representing the state which is created for each {@link Trace}. Contains the globally non-unique identifier of
  * a trace and a request identifier used to identify different requests sent from the same trace.
  */
-final class CommonTraceState implements Serializable {
+final class TraceState implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final String traceId;
@@ -36,13 +36,13 @@ final class CommonTraceState implements Serializable {
     @Nullable
     private final String requestId;
 
-    static CommonTraceState of(String traceId, Optional<String> requestId) {
+    static TraceState of(String traceId, Optional<String> requestId) {
         checkArgument(!Strings.isNullOrEmpty(traceId), "traceId must be non-empty");
         checkNotNull(requestId, "requestId should be not-null");
-        return new CommonTraceState(traceId, requestId.orElse(null));
+        return new TraceState(traceId, requestId.orElse(null));
     }
 
-    private CommonTraceState(String traceId, @Nullable String requestId) {
+    private TraceState(String traceId, @Nullable String requestId) {
         this.traceId = traceId;
         this.requestId = requestId;
     }
@@ -50,7 +50,7 @@ final class CommonTraceState implements Serializable {
     /**
      * The globally unique non-empty identifier for this call trace.
      * */
-    String getTraceId() {
+    String traceId() {
         return traceId;
     }
 
@@ -62,16 +62,12 @@ final class CommonTraceState implements Serializable {
      * distinguish between requests with the same traceId.
      */
     @Nullable
-    String getRequestId() {
-        return Optional.ofNullable(requestId);
-    }
-
-    CommonTraceState deepCopy() {
-        return new CommonTraceState(traceId, requestId);
+    String requestId() {
+        return requestId;
     }
 
     @Override
     public String toString() {
-        return "CommonTraceState{traceId='" + traceId + "', requestId=" + requestId + '}';
+        return "TraceState{traceId='" + traceId + "', requestId=" + requestId + '}';
     }
 }

--- a/tracing/src/main/java/com/palantir/tracing/TraceState.java
+++ b/tracing/src/main/java/com/palantir/tracing/TraceState.java
@@ -68,6 +68,6 @@ final class TraceState implements Serializable {
 
     @Override
     public String toString() {
-        return "TraceState{traceId='" + traceId + "', requestId=" + requestId + '}';
+        return "TraceState{traceId='" + traceId + "', requestId='" + requestId + "'}";
     }
 }

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -588,8 +588,7 @@ public final class Tracer {
         if (trace != null) {
             Optional<OpenSpan> span = popCurrentSpan(trace);
             if (trace.isObservable()) {
-                completeSpanAndNotifyObservers(
-                        span, tag, state, trace.getTraceState().traceId());
+                completeSpanAndNotifyObservers(span, tag, state, trace.getTraceId());
             }
         }
     }
@@ -624,11 +623,7 @@ public final class Tracer {
             return Optional.empty();
         }
         Optional<Span> maybeSpan = popCurrentSpan(trace)
-                .map(openSpan -> toSpan(
-                        openSpan,
-                        MapTagTranslator.INSTANCE,
-                        metadata,
-                        trace.getTraceState().traceId()));
+                .map(openSpan -> toSpan(openSpan, MapTagTranslator.INSTANCE, metadata, trace.getTraceId()));
 
         // Notify subscribers iff trace is observable
         if (maybeSpan.isPresent() && trace.isObservable()) {
@@ -752,9 +747,7 @@ public final class Tracer {
      * Returns the globally unique identifier for this thread's trace.
      */
     public static String getTraceId() {
-        return checkNotNull(currentTrace.get(), "There is no trace")
-                .getTraceState()
-                .traceId();
+        return checkNotNull(currentTrace.get(), "There is no trace").getTraceId();
     }
 
     /**

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -74,7 +74,7 @@ public final class Tracer {
     private static Trace createTrace(Observability observability, String traceId, Optional<String> requestId) {
         checkArgument(!Strings.isNullOrEmpty(traceId), "traceId must be non-empty");
         boolean observable = shouldObserve(observability);
-        return Trace.of(observable, CommonTraceState.create(traceId, requestId));
+        return Trace.of(observable, CommonTraceState.of(traceId, requestId));
     }
 
     private static boolean shouldObserve(Observability observability) {
@@ -272,8 +272,8 @@ public final class Tracer {
         // The current trace has no impact on this function, a new trace is spawned and existing thread state
         // is not modified.
         return shouldObserve(observability)
-                ? new SampledDetachedSpan(operation, type, CommonTraceState.create(traceId, requestId), parentSpanId)
-                : new UnsampledDetachedSpan(CommonTraceState.create(traceId, requestId), parentSpanId);
+                ? new SampledDetachedSpan(operation, type, CommonTraceState.of(traceId, requestId), parentSpanId)
+                : new UnsampledDetachedSpan(CommonTraceState.of(traceId, requestId), parentSpanId);
     }
 
     /**
@@ -311,7 +311,7 @@ public final class Tracer {
         if (maybeCurrentTrace != null) {
             return maybeCurrentTrace.getCommonTraceState();
         }
-        return CommonTraceState.create(Tracers.randomId(), getRequestIdForSpan(newSpanType));
+        return CommonTraceState.of(Tracers.randomId(), getRequestIdForSpan(newSpanType));
     }
 
     private static Optional<String> getRequestIdForSpan(SpanType newSpanType) {

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -451,9 +451,8 @@ public final class Tracer {
         public String toString() {
             return "SampledDetachedSpan{completed="
                     + (completed == COMPLETE)
-                    + ", traceState='"
+                    + ", traceState="
                     + traceState
-                    + '\''
                     + ", openSpan="
                     + openSpan
                     + '}';
@@ -490,7 +489,7 @@ public final class Tracer {
 
         @Override
         public String toString() {
-            return "SampledDetached{traceState='" + traceState + '\'' + ", openSpan=" + openSpan + '}';
+            return "SampledDetached{traceState=" + traceState + ", openSpan=" + openSpan + '}';
         }
     }
 
@@ -544,7 +543,7 @@ public final class Tracer {
 
         @Override
         public String toString() {
-            return "UnsampledDetachedSpan{traceState='" + traceState + "'}";
+            return "UnsampledDetachedSpan{traceState=" + traceState + '}';
         }
     }
 

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -74,7 +74,7 @@ public final class Tracer {
     private static Trace createTrace(Observability observability, String traceId, Optional<String> requestId) {
         checkArgument(!Strings.isNullOrEmpty(traceId), "traceId must be non-empty");
         boolean observable = shouldObserve(observability);
-        return Trace.of(observable, traceId, requestId);
+        return Trace.of(observable, CommonTraceState.create(traceId, requestId));
     }
 
     private static boolean shouldObserve(Observability observability) {
@@ -117,15 +117,15 @@ public final class Tracer {
             return trace.top().map(openSpan -> TraceMetadata.builder()
                     .spanId(openSpan.getSpanId())
                     .parentSpanId(openSpan.getParentSpanId())
-                    .traceId(trace.getTraceId())
-                    .requestId(trace.getRequestId())
+                    .traceId(trace.getCommonTraceState().getTraceId())
+                    .requestId(trace.getCommonTraceState().getRequestId())
                     .build());
         } else {
             return Optional.of(TraceMetadata.builder()
                     .spanId(Tracers.randomId())
                     .parentSpanId(Optional.empty())
-                    .traceId(trace.getTraceId())
-                    .requestId(trace.getRequestId())
+                    .traceId(trace.getCommonTraceState().getTraceId())
+                    .requestId(trace.getCommonTraceState().getRequestId())
                     .build());
         }
     }
@@ -235,13 +235,12 @@ public final class Tracer {
      */
     static DetachedSpan detachInternal(@Safe String operation, SpanType type) {
         Trace maybeCurrentTrace = currentTrace.get();
-        String traceId = maybeCurrentTrace != null ? maybeCurrentTrace.getTraceId() : Tracers.randomId();
+        CommonTraceState commonTraceState = getCommonTraceState(maybeCurrentTrace, type);
         boolean sampled = maybeCurrentTrace != null ? maybeCurrentTrace.isObservable() : sampler.sample();
         Optional<String> parentSpan = getParentSpanId(maybeCurrentTrace);
-        Optional<String> requestId = getRequestId(maybeCurrentTrace, type);
         return sampled
-                ? new SampledDetachedSpan(operation, type, traceId, requestId, parentSpan)
-                : new UnsampledDetachedSpan(traceId, requestId, Optional.empty());
+                ? new SampledDetachedSpan(operation, type, commonTraceState, parentSpan)
+                : new UnsampledDetachedSpan(commonTraceState, Optional.empty());
     }
 
     /**
@@ -273,8 +272,8 @@ public final class Tracer {
         // The current trace has no impact on this function, a new trace is spawned and existing thread state
         // is not modified.
         return shouldObserve(observability)
-                ? new SampledDetachedSpan(operation, type, traceId, requestId, parentSpanId)
-                : new UnsampledDetachedSpan(traceId, requestId, parentSpanId);
+                ? new SampledDetachedSpan(operation, type, CommonTraceState.create(traceId, requestId), parentSpanId)
+                : new UnsampledDetachedSpan(CommonTraceState.create(traceId, requestId), parentSpanId);
     }
 
     /**
@@ -287,16 +286,14 @@ public final class Tracer {
             return NopDetached.INSTANCE;
         }
 
-        String traceId = trace.getTraceId();
-        Optional<String> requestId = trace.getRequestId();
         if (trace.isObservable()) {
             OpenSpan maybeOpenSpan = trace.top().orElse(null);
             if (maybeOpenSpan == null) {
                 return NopDetached.INSTANCE;
             }
-            return new SampledDetached(traceId, requestId, maybeOpenSpan);
+            return new SampledDetached(trace.getCommonTraceState(), maybeOpenSpan);
         } else {
-            return new UnsampledDetachedSpan(traceId, requestId, Optional.empty());
+            return new UnsampledDetachedSpan(trace.getCommonTraceState(), Optional.empty());
         }
     }
 
@@ -310,10 +307,14 @@ public final class Tracer {
         return Optional.empty();
     }
 
-    private static Optional<String> getRequestId(@Nullable Trace maybeCurrentTrace, SpanType newSpanType) {
+    private static CommonTraceState getCommonTraceState(@Nullable Trace maybeCurrentTrace, SpanType newSpanType) {
         if (maybeCurrentTrace != null) {
-            return maybeCurrentTrace.getRequestId();
+            return maybeCurrentTrace.getCommonTraceState();
         }
+        return CommonTraceState.create(Tracers.randomId(), getRequestIdForSpan(newSpanType));
+    }
+
+    private static Optional<String> getRequestIdForSpan(SpanType newSpanType) {
         if (newSpanType == SpanType.SERVER_INCOMING) {
             return Optional.of(Tracers.randomId());
         }
@@ -322,10 +323,10 @@ public final class Tracer {
 
     static Optional<String> getRequestId(DetachedSpan detachedSpan) {
         if (detachedSpan instanceof SampledDetachedSpan) {
-            return ((SampledDetachedSpan) detachedSpan).requestId;
+            return ((SampledDetachedSpan) detachedSpan).commonTraceState.getRequestId();
         }
         if (detachedSpan instanceof UnsampledDetachedSpan) {
-            return ((UnsampledDetachedSpan) detachedSpan).requestId;
+            return ((UnsampledDetachedSpan) detachedSpan).commonTraceState.getRequestId();
         }
         throw new SafeIllegalStateException("Unknown span type", SafeArg.of("detachedSpan", detachedSpan));
     }
@@ -372,8 +373,7 @@ public final class Tracer {
         private static final AtomicIntegerFieldUpdater<SampledDetachedSpan> completedUpdater =
                 AtomicIntegerFieldUpdater.newUpdater(SampledDetachedSpan.class, "completed");
 
-        private final String traceId;
-        private final Optional<String> requestId;
+        private final CommonTraceState commonTraceState;
         private final OpenSpan openSpan;
 
         private volatile int completed;
@@ -381,27 +381,21 @@ public final class Tracer {
         @SuppressWarnings("ImmutablesBuilderMissingInitialization")
         // OpenSpan#builder sets these
         SampledDetachedSpan(
-                String operation,
-                SpanType type,
-                String traceId,
-                Optional<String> requestId,
-                Optional<String> parentSpanId) {
-            this.traceId = traceId;
-            this.requestId = requestId;
+                String operation, SpanType type, CommonTraceState commonTraceState, Optional<String> parentSpanId) {
+            this.commonTraceState = commonTraceState;
             this.openSpan = OpenSpan.of(operation, Tracers.randomId(), type, parentSpanId);
         }
 
         @MustBeClosed
         private static <T> CloseableSpan childSpan(
-                String traceId,
+                CommonTraceState commonTraceState,
                 OpenSpan openSpan,
-                Optional<String> requestId,
                 String operationName,
                 TagTranslator<? super T> translator,
                 T data,
                 SpanType type) {
             Trace maybeCurrentTrace = currentTrace.get();
-            setTrace(Trace.of(true, traceId, requestId));
+            setTrace(Trace.of(true, commonTraceState));
             Tracer.fastStartSpan(operationName, openSpan.getSpanId(), type);
             return TraceRestoringCloseableSpanWithMetadata.of(maybeCurrentTrace, translator, data);
         }
@@ -410,18 +404,18 @@ public final class Tracer {
         @MustBeClosed
         public <T> CloseableSpan childSpan(
                 String operationName, TagTranslator<? super T> translator, T data, SpanType type) {
-            return childSpan(traceId, openSpan, requestId, operationName, translator, data, type);
+            return childSpan(commonTraceState, openSpan, operationName, translator, data, type);
         }
 
         @Override
         public DetachedSpan childDetachedSpan(String operation, SpanType type) {
-            return new SampledDetachedSpan(operation, type, traceId, requestId, Optional.of(openSpan.getSpanId()));
+            return new SampledDetachedSpan(operation, type, commonTraceState, Optional.of(openSpan.getSpanId()));
         }
 
         @MustBeClosed
-        private static CloseableSpan attach(String traceId, OpenSpan openSpan, Optional<String> requestId) {
+        private static CloseableSpan attach(OpenSpan openSpan, CommonTraceState commonTraceState) {
             Trace maybeCurrentTrace = currentTrace.get();
-            Trace newTrace = Trace.of(true, traceId, requestId);
+            Trace newTrace = Trace.of(true, commonTraceState);
             // Push the DetachedSpan OpenSpan to provide the correct parent information
             // to child spans created within the context of this attach.
             // It is VITAL that this span is never completed, it exists only for attribution.
@@ -435,7 +429,7 @@ public final class Tracer {
         @Override
         @MustBeClosed
         public CloseableSpan attach() {
-            return attach(traceId, openSpan, requestId);
+            return attach(openSpan, commonTraceState);
         }
 
         @Override
@@ -446,7 +440,7 @@ public final class Tracer {
         @Override
         public <T> void complete(TagTranslator<? super T> tagTranslator, T data) {
             if (NOT_COMPLETE == completedUpdater.getAndSet(this, COMPLETE)) {
-                Tracer.notifyObservers(toSpan(openSpan, tagTranslator, data, traceId));
+                Tracer.notifyObservers(toSpan(openSpan, tagTranslator, data, commonTraceState.getTraceId()));
             }
         }
 
@@ -454,11 +448,8 @@ public final class Tracer {
         public String toString() {
             return "SampledDetachedSpan{completed="
                     + (completed == COMPLETE)
-                    + ", traceId='"
-                    + traceId
-                    + '\''
-                    + ", requestId='"
-                    + requestId.orElse(null)
+                    + ", commonTraceState='"
+                    + commonTraceState
                     + '\''
                     + ", openSpan="
                     + openSpan
@@ -468,13 +459,11 @@ public final class Tracer {
 
     private static final class SampledDetached implements Detached {
 
-        private final String traceId;
-        private final Optional<String> requestId;
+        private final CommonTraceState commonTraceState;
         private final OpenSpan openSpan;
 
-        SampledDetached(String traceId, Optional<String> requestId, OpenSpan openSpan) {
-            this.traceId = traceId;
-            this.requestId = requestId;
+        SampledDetached(CommonTraceState commonTraceState, OpenSpan openSpan) {
+            this.commonTraceState = commonTraceState;
             this.openSpan = openSpan;
         }
 
@@ -482,43 +471,33 @@ public final class Tracer {
         @MustBeClosed
         public <T> CloseableSpan childSpan(
                 String operationName, TagTranslator<? super T> translator, T data, SpanType type) {
-            return SampledDetachedSpan.childSpan(traceId, openSpan, requestId, operationName, translator, data, type);
+            return SampledDetachedSpan.childSpan(commonTraceState, openSpan, operationName, translator, data, type);
         }
 
         @Override
         public DetachedSpan childDetachedSpan(String operation, SpanType type) {
-            return new SampledDetachedSpan(operation, type, traceId, requestId, Optional.of(openSpan.getSpanId()));
+            return new SampledDetachedSpan(operation, type, commonTraceState, Optional.of(openSpan.getSpanId()));
         }
 
         @Override
         @MustBeClosed
         public CloseableSpan attach() {
-            return SampledDetachedSpan.attach(traceId, openSpan, requestId);
+            return SampledDetachedSpan.attach(openSpan, commonTraceState);
         }
 
         @Override
         public String toString() {
-            return "SampledDetached{traceId='"
-                    + traceId
-                    + '\''
-                    + ", requestId='"
-                    + requestId.orElse(null)
-                    + '\''
-                    + ", openSpan="
-                    + openSpan
-                    + '}';
+            return "SampledDetached{commonTraceState='" + commonTraceState + '\'' + ", openSpan=" + openSpan + '}';
         }
     }
 
     private static final class UnsampledDetachedSpan implements DetachedSpan {
 
-        private final String traceId;
-        private final Optional<String> requestId;
+        private final CommonTraceState commonTraceState;
         private final Optional<String> parentSpanId;
 
-        UnsampledDetachedSpan(String traceId, Optional<String> requestId, Optional<String> parentSpanId) {
-            this.traceId = traceId;
-            this.requestId = requestId;
+        UnsampledDetachedSpan(CommonTraceState commonTraceState, Optional<String> parentSpanId) {
+            this.commonTraceState = commonTraceState;
             this.parentSpanId = parentSpanId;
         }
 
@@ -526,7 +505,7 @@ public final class Tracer {
         public <T> CloseableSpan childSpan(
                 String operationName, TagTranslator<? super T> _translator, T _data, SpanType type) {
             Trace maybeCurrentTrace = currentTrace.get();
-            setTrace(Trace.of(false, traceId, requestId));
+            setTrace(Trace.of(false, commonTraceState));
             if (parentSpanId.isPresent()) {
                 Tracer.fastStartSpan(operationName, parentSpanId.get(), type);
             } else {
@@ -562,7 +541,7 @@ public final class Tracer {
 
         @Override
         public String toString() {
-            return "UnsampledDetachedSpan{traceId='" + traceId + "', requestId='" + requestId.orElse(null) + "'}";
+            return "UnsampledDetachedSpan{commonTraceState='" + commonTraceState + "'}";
         }
     }
 
@@ -607,7 +586,8 @@ public final class Tracer {
         if (trace != null) {
             Optional<OpenSpan> span = popCurrentSpan(trace);
             if (trace.isObservable()) {
-                completeSpanAndNotifyObservers(span, tag, state, trace.getTraceId());
+                completeSpanAndNotifyObservers(
+                        span, tag, state, trace.getCommonTraceState().getTraceId());
             }
         }
     }
@@ -642,7 +622,11 @@ public final class Tracer {
             return Optional.empty();
         }
         Optional<Span> maybeSpan = popCurrentSpan(trace)
-                .map(openSpan -> toSpan(openSpan, MapTagTranslator.INSTANCE, metadata, trace.getTraceId()));
+                .map(openSpan -> toSpan(
+                        openSpan,
+                        MapTagTranslator.INSTANCE,
+                        metadata,
+                        trace.getCommonTraceState().getTraceId()));
 
         // Notify subscribers iff trace is observable
         if (maybeSpan.isPresent() && trace.isObservable()) {
@@ -766,7 +750,9 @@ public final class Tracer {
      * Returns the globally unique identifier for this thread's trace.
      */
     public static String getTraceId() {
-        return checkNotNull(currentTrace.get(), "There is no trace").getTraceId();
+        return checkNotNull(currentTrace.get(), "There is no trace")
+                .getCommonTraceState()
+                .getTraceId();
     }
 
     /**
@@ -824,9 +810,9 @@ public final class Tracer {
         currentTrace.set(trace);
 
         // Give log appenders access to the trace id and whether the trace is being sampled
-        MDC.put(Tracers.TRACE_ID_KEY, trace.getTraceId());
+        MDC.put(Tracers.TRACE_ID_KEY, trace.getCommonTraceState().getTraceId());
         setTraceSampledMdcIfObservable(trace.isObservable());
-        setTraceRequestId(trace.getRequestId());
+        setTraceRequestId(trace.getCommonTraceState().getRequestId());
 
         logSettingTrace();
     }

--- a/tracing/src/test/java/com/palantir/tracing/TraceTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TraceTest.java
@@ -28,12 +28,13 @@ public final class TraceTest {
 
     @Test
     public void constructTrace_emptyTraceId() {
-        assertThatThrownBy(() -> Trace.of(false, "", Optional.empty())).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Trace.of(false, CommonTraceState.create("", Optional.empty())))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void testToString() {
-        Trace trace = Trace.of(true, "traceId", Optional.empty());
+        Trace trace = Trace.of(true, CommonTraceState.create("traceId", Optional.empty()));
         OpenSpan span = trace.startSpan("operation", SpanType.LOCAL);
         assertThat(trace.toString())
                 .isEqualTo("Trace{stack=[" + span + "], isObservable=true, traceId='traceId'}")

--- a/tracing/src/test/java/com/palantir/tracing/TraceTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TraceTest.java
@@ -37,7 +37,10 @@ public final class TraceTest {
         Trace trace = Trace.of(true, TraceState.of("traceId", Optional.empty()));
         OpenSpan span = trace.startSpan("operation", SpanType.LOCAL);
         assertThat(trace.toString())
-                .isEqualTo("Trace{stack=[" + span + "], isObservable=true, traceId='traceId'}")
+                .isEqualTo("Trace{"
+                        + "stack=[" + span + "], "
+                        + "isObservable=true, "
+                        + "state=TraceState{traceId='traceId', requestId='null'}}")
                 .contains(span.getOperation())
                 .contains(span.getSpanId());
     }

--- a/tracing/src/test/java/com/palantir/tracing/TraceTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TraceTest.java
@@ -28,13 +28,13 @@ public final class TraceTest {
 
     @Test
     public void constructTrace_emptyTraceId() {
-        assertThatThrownBy(() -> Trace.of(false, CommonTraceState.of("", Optional.empty())))
+        assertThatThrownBy(() -> Trace.of(false, TraceState.of("", Optional.empty())))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void testToString() {
-        Trace trace = Trace.of(true, CommonTraceState.of("traceId", Optional.empty()));
+        Trace trace = Trace.of(true, TraceState.of("traceId", Optional.empty()));
         OpenSpan span = trace.startSpan("operation", SpanType.LOCAL);
         assertThat(trace.toString())
                 .isEqualTo("Trace{stack=[" + span + "], isObservable=true, traceId='traceId'}")

--- a/tracing/src/test/java/com/palantir/tracing/TraceTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TraceTest.java
@@ -28,13 +28,13 @@ public final class TraceTest {
 
     @Test
     public void constructTrace_emptyTraceId() {
-        assertThatThrownBy(() -> Trace.of(false, CommonTraceState.create("", Optional.empty())))
+        assertThatThrownBy(() -> Trace.of(false, CommonTraceState.of("", Optional.empty())))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void testToString() {
-        Trace trace = Trace.of(true, CommonTraceState.create("traceId", Optional.empty()));
+        Trace trace = Trace.of(true, CommonTraceState.of("traceId", Optional.empty()));
         OpenSpan span = trace.startSpan("operation", SpanType.LOCAL);
         assertThat(trace.toString())
                 .isEqualTo("Trace{stack=[" + span + "], isObservable=true, traceId='traceId'}")

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -355,7 +355,7 @@ public final class TracerTest {
             assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(startTrace);
 
             Trace oldTrace = Tracer.getAndClearTrace();
-            assertThat(oldTrace.getTraceState().traceId()).isEqualTo(startTrace);
+            assertThat(oldTrace.getTraceId()).isEqualTo(startTrace);
             assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isNull(); // after clearing, it's empty
         } finally {
             Tracer.fastCompleteSpan();

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -146,14 +146,14 @@ public final class TracerTest {
     public void testObserversAreInvokedOnObservableTracesOnly() throws Exception {
         Tracer.subscribe("1", observer1);
 
-        Tracer.setTrace(Trace.of(true, CommonTraceState.of(Tracers.randomId(), Optional.empty())));
+        Tracer.setTrace(Trace.of(true, TraceState.of(Tracers.randomId(), Optional.empty())));
         Span span = startAndCompleteSpan();
         verify(observer1).consume(span);
         span = startAndCompleteSpan();
         verify(observer1).consume(span);
         verifyNoMoreInteractions(observer1);
 
-        Tracer.setTrace(Trace.of(false, CommonTraceState.of(Tracers.randomId(), Optional.empty())));
+        Tracer.setTrace(Trace.of(false, TraceState.of(Tracers.randomId(), Optional.empty())));
         startAndFastCompleteSpan(); // not sampled, see above
         verifyNoMoreInteractions(observer1);
     }
@@ -164,7 +164,7 @@ public final class TracerTest {
         assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isNull();
         assertThat(Tracer.hasTraceId()).isFalse();
         assertThat(Tracer.hasUnobservableTrace()).isFalse();
-        Tracer.setTrace(Trace.of(false, CommonTraceState.of(traceId, Optional.empty())));
+        Tracer.setTrace(Trace.of(false, TraceState.of(traceId, Optional.empty())));
         // Unsampled trace should still apply thread state
         assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(traceId);
         assertThat(Tracer.hasTraceId()).isTrue();
@@ -218,7 +218,7 @@ public final class TracerTest {
     @Test
     public void testSetTraceSetsCurrentTraceAndMdcTraceIdKey() throws Exception {
         Tracer.fastStartSpan("operation");
-        Tracer.setTrace(Trace.of(true, CommonTraceState.of("newTraceId", Optional.empty())));
+        Tracer.setTrace(Trace.of(true, TraceState.of("newTraceId", Optional.empty())));
         assertThat(Tracer.getTraceId()).isEqualTo("newTraceId");
         assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo("newTraceId");
         assertThat(Tracer.completeSpan()).isEmpty();
@@ -227,7 +227,7 @@ public final class TracerTest {
 
     @Test
     public void testSetTraceSetsMdcTraceSampledKeyWhenObserved() {
-        Tracer.setTrace(Trace.of(true, CommonTraceState.of("observedTraceId", Optional.empty())));
+        Tracer.setTrace(Trace.of(true, TraceState.of("observedTraceId", Optional.empty())));
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isEqualTo("1");
         assertThat(Tracer.completeSpan()).isEmpty();
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isNull();
@@ -235,7 +235,7 @@ public final class TracerTest {
 
     @Test
     public void testSetTraceMissingMdcTraceSampledKeyWhenNotObserved() {
-        Tracer.setTrace(Trace.of(false, CommonTraceState.of("notObservedTraceId", Optional.empty())));
+        Tracer.setTrace(Trace.of(false, TraceState.of("notObservedTraceId", Optional.empty())));
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isNull();
         assertThat(Tracer.completeSpan()).isEmpty();
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isNull();
@@ -336,7 +336,7 @@ public final class TracerTest {
 
     @Test
     public void testGetAndClearTraceIfPresent() {
-        Trace trace = Trace.of(true, CommonTraceState.of("newTraceId", Optional.empty()));
+        Trace trace = Trace.of(true, TraceState.of("newTraceId", Optional.empty()));
         Tracer.setTrace(trace);
 
         Optional<Trace> nonEmptyTrace = Tracer.getAndClearTraceIfPresent();
@@ -355,7 +355,7 @@ public final class TracerTest {
             assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(startTrace);
 
             Trace oldTrace = Tracer.getAndClearTrace();
-            assertThat(oldTrace.getCommonTraceState().getTraceId()).isEqualTo(startTrace);
+            assertThat(oldTrace.getTraceState().traceId()).isEqualTo(startTrace);
             assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isNull(); // after clearing, it's empty
         } finally {
             Tracer.fastCompleteSpan();

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -146,14 +146,14 @@ public final class TracerTest {
     public void testObserversAreInvokedOnObservableTracesOnly() throws Exception {
         Tracer.subscribe("1", observer1);
 
-        Tracer.setTrace(Trace.of(true, CommonTraceState.create(Tracers.randomId(), Optional.empty())));
+        Tracer.setTrace(Trace.of(true, CommonTraceState.of(Tracers.randomId(), Optional.empty())));
         Span span = startAndCompleteSpan();
         verify(observer1).consume(span);
         span = startAndCompleteSpan();
         verify(observer1).consume(span);
         verifyNoMoreInteractions(observer1);
 
-        Tracer.setTrace(Trace.of(false, CommonTraceState.create(Tracers.randomId(), Optional.empty())));
+        Tracer.setTrace(Trace.of(false, CommonTraceState.of(Tracers.randomId(), Optional.empty())));
         startAndFastCompleteSpan(); // not sampled, see above
         verifyNoMoreInteractions(observer1);
     }
@@ -164,7 +164,7 @@ public final class TracerTest {
         assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isNull();
         assertThat(Tracer.hasTraceId()).isFalse();
         assertThat(Tracer.hasUnobservableTrace()).isFalse();
-        Tracer.setTrace(Trace.of(false, CommonTraceState.create(traceId, Optional.empty())));
+        Tracer.setTrace(Trace.of(false, CommonTraceState.of(traceId, Optional.empty())));
         // Unsampled trace should still apply thread state
         assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(traceId);
         assertThat(Tracer.hasTraceId()).isTrue();
@@ -218,7 +218,7 @@ public final class TracerTest {
     @Test
     public void testSetTraceSetsCurrentTraceAndMdcTraceIdKey() throws Exception {
         Tracer.fastStartSpan("operation");
-        Tracer.setTrace(Trace.of(true, CommonTraceState.create("newTraceId", Optional.empty())));
+        Tracer.setTrace(Trace.of(true, CommonTraceState.of("newTraceId", Optional.empty())));
         assertThat(Tracer.getTraceId()).isEqualTo("newTraceId");
         assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo("newTraceId");
         assertThat(Tracer.completeSpan()).isEmpty();
@@ -227,7 +227,7 @@ public final class TracerTest {
 
     @Test
     public void testSetTraceSetsMdcTraceSampledKeyWhenObserved() {
-        Tracer.setTrace(Trace.of(true, CommonTraceState.create("observedTraceId", Optional.empty())));
+        Tracer.setTrace(Trace.of(true, CommonTraceState.of("observedTraceId", Optional.empty())));
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isEqualTo("1");
         assertThat(Tracer.completeSpan()).isEmpty();
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isNull();
@@ -235,7 +235,7 @@ public final class TracerTest {
 
     @Test
     public void testSetTraceMissingMdcTraceSampledKeyWhenNotObserved() {
-        Tracer.setTrace(Trace.of(false, CommonTraceState.create("notObservedTraceId", Optional.empty())));
+        Tracer.setTrace(Trace.of(false, CommonTraceState.of("notObservedTraceId", Optional.empty())));
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isNull();
         assertThat(Tracer.completeSpan()).isEmpty();
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isNull();
@@ -336,7 +336,7 @@ public final class TracerTest {
 
     @Test
     public void testGetAndClearTraceIfPresent() {
-        Trace trace = Trace.of(true, CommonTraceState.create("newTraceId", Optional.empty()));
+        Trace trace = Trace.of(true, CommonTraceState.of("newTraceId", Optional.empty()));
         Tracer.setTrace(trace);
 
         Optional<Trace> nonEmptyTrace = Tracer.getAndClearTraceIfPresent();

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -146,14 +146,14 @@ public final class TracerTest {
     public void testObserversAreInvokedOnObservableTracesOnly() throws Exception {
         Tracer.subscribe("1", observer1);
 
-        Tracer.setTrace(Trace.of(true, Tracers.randomId(), Optional.empty()));
+        Tracer.setTrace(Trace.of(true, CommonTraceState.create(Tracers.randomId(), Optional.empty())));
         Span span = startAndCompleteSpan();
         verify(observer1).consume(span);
         span = startAndCompleteSpan();
         verify(observer1).consume(span);
         verifyNoMoreInteractions(observer1);
 
-        Tracer.setTrace(Trace.of(false, Tracers.randomId(), Optional.empty()));
+        Tracer.setTrace(Trace.of(false, CommonTraceState.create(Tracers.randomId(), Optional.empty())));
         startAndFastCompleteSpan(); // not sampled, see above
         verifyNoMoreInteractions(observer1);
     }
@@ -164,7 +164,7 @@ public final class TracerTest {
         assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isNull();
         assertThat(Tracer.hasTraceId()).isFalse();
         assertThat(Tracer.hasUnobservableTrace()).isFalse();
-        Tracer.setTrace(Trace.of(false, traceId, Optional.empty()));
+        Tracer.setTrace(Trace.of(false, CommonTraceState.create(traceId, Optional.empty())));
         // Unsampled trace should still apply thread state
         assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(traceId);
         assertThat(Tracer.hasTraceId()).isTrue();
@@ -218,7 +218,7 @@ public final class TracerTest {
     @Test
     public void testSetTraceSetsCurrentTraceAndMdcTraceIdKey() throws Exception {
         Tracer.fastStartSpan("operation");
-        Tracer.setTrace(Trace.of(true, "newTraceId", Optional.empty()));
+        Tracer.setTrace(Trace.of(true, CommonTraceState.create("newTraceId", Optional.empty())));
         assertThat(Tracer.getTraceId()).isEqualTo("newTraceId");
         assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo("newTraceId");
         assertThat(Tracer.completeSpan()).isEmpty();
@@ -227,7 +227,7 @@ public final class TracerTest {
 
     @Test
     public void testSetTraceSetsMdcTraceSampledKeyWhenObserved() {
-        Tracer.setTrace(Trace.of(true, "observedTraceId", Optional.empty()));
+        Tracer.setTrace(Trace.of(true, CommonTraceState.create("observedTraceId", Optional.empty())));
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isEqualTo("1");
         assertThat(Tracer.completeSpan()).isEmpty();
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isNull();
@@ -235,7 +235,7 @@ public final class TracerTest {
 
     @Test
     public void testSetTraceMissingMdcTraceSampledKeyWhenNotObserved() {
-        Tracer.setTrace(Trace.of(false, "notObservedTraceId", Optional.empty()));
+        Tracer.setTrace(Trace.of(false, CommonTraceState.create("notObservedTraceId", Optional.empty())));
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isNull();
         assertThat(Tracer.completeSpan()).isEmpty();
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isNull();
@@ -336,7 +336,7 @@ public final class TracerTest {
 
     @Test
     public void testGetAndClearTraceIfPresent() {
-        Trace trace = Trace.of(true, "newTraceId", Optional.empty());
+        Trace trace = Trace.of(true, CommonTraceState.create("newTraceId", Optional.empty()));
         Tracer.setTrace(trace);
 
         Optional<Trace> nonEmptyTrace = Tracer.getAndClearTraceIfPresent();
@@ -355,7 +355,7 @@ public final class TracerTest {
             assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(startTrace);
 
             Trace oldTrace = Tracer.getAndClearTrace();
-            assertThat(oldTrace.getTraceId()).isEqualTo(startTrace);
+            assertThat(oldTrace.getCommonTraceState().getTraceId()).isEqualTo(startTrace);
             assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isNull(); // after clearing, it's empty
         } finally {
             Tracer.fastCompleteSpan();


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Based on comments from #782 I extracted a `CommonTraceState` which contains the requestId and traceId. I'm not sure about the following changes:
1. Should the `getTraceId` and `getRequestId` be removed completely?
2. Making the `CommonTraceState` serializable introduced the nullable field for reqeustId and I'm not sure if the getter which wraps this nullable can be changed with something smarter.


