### PR TITLE
Trace threadlocal entry is never removed, only nulled

### DIFF
--- a/changelog/@unreleased/pr-849.v2.yml
+++ b/changelog/@unreleased/pr-849.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Trace threadlocal entry is never removed, only nulled
+  links:
+  - https://github.com/palantir/tracing-java/pull/849

--- a/tracing-benchmarks/build.gradle
+++ b/tracing-benchmarks/build.gradle
@@ -16,7 +16,7 @@ tasks.jmhCompileGeneratedClasses {
 }
 
 dependencies {
-    annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
+    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
     compileOnly 'org.openjdk.jmh:jmh-generator-annprocess'
     api 'org.immutables:value::annotations'
     api 'org.openjdk.jmh:jmh-core'

--- a/tracing-benchmarks/src/jmh/java/com/palantir/tracing/TracingBenchmark.java
+++ b/tracing-benchmarks/src/jmh/java/com/palantir/tracing/TracingBenchmark.java
@@ -88,6 +88,12 @@ public class TracingBenchmark {
         nestedSpans.run();
     }
 
+    @Benchmark
+    public static void traceWithSingleSpan() {
+        Tracer.fastStartSpan("benchmark");
+        Tracer.fastCompleteSpan();
+    }
+
     private static Runnable createNestedSpan(int depth) {
         if (depth <= 0) {
             return Runnables.doNothing();

--- a/tracing-benchmarks/src/jmh/java/com/palantir/tracing/TracingBenchmark.java
+++ b/tracing-benchmarks/src/jmh/java/com/palantir/tracing/TracingBenchmark.java
@@ -43,7 +43,7 @@ import org.openjdk.jmh.runner.options.TimeValue;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
-@Fork(1)
+@Fork(value = 1, jvmArgsAppend = "-Dlog4j2.garbagefreeThreadContextMap=true")
 @Threads(4)
 @SuppressWarnings({"checkstyle:hideutilityclassconstructor", "checkstyle:VisibilityModifier"})
 public class TracingBenchmark {

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -919,7 +919,7 @@ public final class Tracer {
     @VisibleForTesting
     static void clearCurrentTrace() {
         logClearingTrace();
-        currentTrace.remove();
+        currentTrace.set(null);
         MDC.remove(Tracers.TRACE_ID_KEY);
         MDC.remove(Tracers.TRACE_SAMPLED_KEY);
         MDC.remove(Tracers.REQUEST_ID_KEY);


### PR DESCRIPTION
This prevents threadlocal map entry churn when traces are added
and cleared, however it comes at the potential cost of larger
threadlocal maps when tracing is not used. We generally expect
everything to be traced, so this shouldn't impact us.

==COMMIT_MSG==
Trace threadlocal entry is never removed, only nulled
==COMMIT_MSG==

## Benchmarks on a single thread:

### BEFORE
```
Benchmark                             (observability)  Mode  Cnt    Score    Error  Units
TracingBenchmark.traceWithSingleSpan           SAMPLE  avgt    3  551.519 ± 57.893  ns/op
TracingBenchmark.traceWithSingleSpan    DO_NOT_SAMPLE  avgt    3  317.826 ± 14.467  ns/op
TracingBenchmark.traceWithSingleSpan        UNDECIDED  avgt    3  342.436 ± 38.777  ns/op
```

```
Benchmark                             (observability)  Mode  Cnt    Score     Error  Units
TracingBenchmark.traceWithSingleSpan           SAMPLE  avgt    3  540.388 ±  69.014  ns/op
TracingBenchmark.traceWithSingleSpan    DO_NOT_SAMPLE  avgt    3  359.699 ± 208.046  ns/op
TracingBenchmark.traceWithSingleSpan        UNDECIDED  avgt    3  362.240 ±  96.292  ns/op
```

### AFTER
```
Benchmark                             (observability)  Mode  Cnt    Score    Error  Units
TracingBenchmark.traceWithSingleSpan           SAMPLE  avgt    3  503.538 ± 20.695  ns/op
TracingBenchmark.traceWithSingleSpan    DO_NOT_SAMPLE  avgt    3  301.762 ± 16.082  ns/op
TracingBenchmark.traceWithSingleSpan        UNDECIDED  avgt    3  323.679 ± 82.884  ns/op
```

```
Benchmark                             (observability)  Mode  Cnt    Score    Error  Units
TracingBenchmark.traceWithSingleSpan           SAMPLE  avgt    3  513.711 ± 21.862  ns/op
TracingBenchmark.traceWithSingleSpan    DO_NOT_SAMPLE  avgt    3  297.156 ± 24.606  ns/op
TracingBenchmark.traceWithSingleSpan        UNDECIDED  avgt    3  319.645 ± 33.003  ns/op
```

## Benchmarks with 20 threads

### 20 threads BEFORE
```
Benchmark                             (observability)  Mode  Cnt     Score     Error  Units
TracingBenchmark.traceWithSingleSpan           SAMPLE  avgt    3  1134.473 ± 305.985  ns/op
TracingBenchmark.traceWithSingleSpan    DO_NOT_SAMPLE  avgt    3  1432.571 ± 409.387  ns/op
TracingBenchmark.traceWithSingleSpan        UNDECIDED  avgt    3  1608.718 ± 335.243  ns/o
```

### 20 threads AFTER
```
Benchmark                             (observability)  Mode  Cnt     Score      Error  Units
TracingBenchmark.traceWithSingleSpan           SAMPLE  avgt    3  1910.558 ±  121.566  ns/op
TracingBenchmark.traceWithSingleSpan    DO_NOT_SAMPLE  avgt    3  1161.873 ± 1048.964  ns/op
TracingBenchmark.traceWithSingleSpan        UNDECIDED  avgt    3  1522.187 ±  375.752  ns/op
```

## GCProfiler benchmarks (gc profiling appears to impact the results)

### Before:
```
Benchmark                                                              (observability)  Mode  Cnt     Score      Error   Units
TracingBenchmark.traceWithSingleSpan                                            SAMPLE  avgt    3   583.999 ±  168.060   ns/op
TracingBenchmark.traceWithSingleSpan:·gc.alloc.rate                             SAMPLE  avgt    3  8685.304 ± 2522.891  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.alloc.rate.norm                        SAMPLE  avgt    3  1552.026 ±    0.012    B/op
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Eden_Space                    SAMPLE  avgt    3  8623.289 ± 4266.756  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Eden_Space.norm               SAMPLE  avgt    3  1540.850 ±  478.658    B/op
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Survivor_Space                SAMPLE  avgt    3     0.014 ±    0.067  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Survivor_Space.norm           SAMPLE  avgt    3     0.002 ±    0.012    B/op
TracingBenchmark.traceWithSingleSpan:·gc.count                                  SAMPLE  avgt    3    64.000             counts
TracingBenchmark.traceWithSingleSpan:·gc.time                                   SAMPLE  avgt    3    67.000                 ms
TracingBenchmark.traceWithSingleSpan                                     DO_NOT_SAMPLE  avgt    3   865.820 ±  345.378   ns/op
TracingBenchmark.traceWithSingleSpan:·gc.alloc.rate                      DO_NOT_SAMPLE  avgt    3  3837.916 ± 1524.525  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.alloc.rate.norm                 DO_NOT_SAMPLE  avgt    3  1016.018 ±    0.026    B/op
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Eden_Space             DO_NOT_SAMPLE  avgt    3  3943.084 ± 4456.074  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Eden_Space.norm        DO_NOT_SAMPLE  avgt    3  1043.879 ± 1104.363    B/op
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Survivor_Space         DO_NOT_SAMPLE  avgt    3     0.007 ±    0.012  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Survivor_Space.norm    DO_NOT_SAMPLE  avgt    3     0.002 ±    0.003    B/op
TracingBenchmark.traceWithSingleSpan:·gc.count                           DO_NOT_SAMPLE  avgt    3    28.000             counts
TracingBenchmark.traceWithSingleSpan:·gc.time                            DO_NOT_SAMPLE  avgt    3    32.000                 ms
TracingBenchmark.traceWithSingleSpan                                         UNDECIDED  avgt    3   765.661 ±   59.218   ns/op
TracingBenchmark.traceWithSingleSpan:·gc.alloc.rate                          UNDECIDED  avgt    3  4363.201 ±  336.582  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.alloc.rate.norm                     UNDECIDED  avgt    3  1021.521 ±    0.202    B/op
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Eden_Space                 UNDECIDED  avgt    3  4361.652 ±   12.487  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Eden_Space.norm            UNDECIDED  avgt    3  1021.169 ±   76.230    B/op
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Survivor_Space             UNDECIDED  avgt    3     0.008 ±    0.019  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Survivor_Space.norm        UNDECIDED  avgt    3     0.002 ±    0.005    B/op
TracingBenchmark.traceWithSingleSpan:·gc.count                               UNDECIDED  avgt    3    30.000             counts
TracingBenchmark.traceWithSingleSpan:·gc.time                                UNDECIDED  avgt    3    29.000                 ms
```

### After:
```
Benchmark                                                              (observability)  Mode  Cnt      Score      Error   Units
TracingBenchmark.traceWithSingleSpan                                            SAMPLE  avgt    3    873.098 ±  290.113   ns/op
TracingBenchmark.traceWithSingleSpan:·gc.alloc.rate                             SAMPLE  avgt    3   5690.967 ± 1876.023  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.alloc.rate.norm                        SAMPLE  avgt    3   1520.026 ±    0.006    B/op
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Eden_Space                    SAMPLE  avgt    3   5774.303 ± 4458.832  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Eden_Space.norm               SAMPLE  avgt    3   1542.644 ± 1313.700    B/op
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Survivor_Space                SAMPLE  avgt    3      0.013 ±    0.074  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Survivor_Space.norm           SAMPLE  avgt    3      0.003 ±    0.019    B/op
TracingBenchmark.traceWithSingleSpan:·gc.count                                  SAMPLE  avgt    3     41.000             counts
TracingBenchmark.traceWithSingleSpan:·gc.time                                   SAMPLE  avgt    3     45.000                 ms
TracingBenchmark.traceWithSingleSpan                                     DO_NOT_SAMPLE  avgt    3    309.315 ±   17.596   ns/op
TracingBenchmark.traceWithSingleSpan:·gc.alloc.rate                      DO_NOT_SAMPLE  avgt    3  10394.631 ±  607.990  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.alloc.rate.norm                 DO_NOT_SAMPLE  avgt    3    984.013 ±    0.004    B/op
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Eden_Space             DO_NOT_SAMPLE  avgt    3  10309.117 ±  123.584  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Eden_Space.norm        DO_NOT_SAMPLE  avgt    3    975.923 ±   48.984    B/op
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Survivor_Space         DO_NOT_SAMPLE  avgt    3      0.015 ±    0.037  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Survivor_Space.norm    DO_NOT_SAMPLE  avgt    3      0.001 ±    0.004    B/op
TracingBenchmark.traceWithSingleSpan:·gc.count                           DO_NOT_SAMPLE  avgt    3     60.000             counts
TracingBenchmark.traceWithSingleSpan:·gc.time                            DO_NOT_SAMPLE  avgt    3     67.000                 ms
TracingBenchmark.traceWithSingleSpan                                         UNDECIDED  avgt    3    829.603 ±  237.847   ns/op
TracingBenchmark.traceWithSingleSpan:·gc.alloc.rate                          UNDECIDED  avgt    3   3898.852 ± 1146.074  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.alloc.rate.norm                     UNDECIDED  avgt    3    989.532 ±    0.041    B/op
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Eden_Space                 UNDECIDED  avgt    3   3974.473 ± 5468.992  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Eden_Space.norm            UNDECIDED  avgt    3   1008.222 ± 1166.486    B/op
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Survivor_Space             UNDECIDED  avgt    3      0.010 ±    0.119  MB/sec
TracingBenchmark.traceWithSingleSpan:·gc.churn.G1_Survivor_Space.norm        UNDECIDED  avgt    3      0.002 ±    0.029    B/op
TracingBenchmark.traceWithSingleSpan:·gc.count                               UNDECIDED  avgt    3     23.000             counts
TracingBenchmark.traceWithSingleSpan:·gc.time                                UNDECIDED  avgt    3     27.000                 ms
```
