### PR TITLE
Tracer#clearCurrentTrace sets thread local current trace to null

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -919,7 +919,7 @@ public final class Tracer {
     @VisibleForTesting
     static void clearCurrentTrace() {
         logClearingTrace();
-        currentTrace.remove();
+        currentTrace.set(null);
         MDC.remove(Tracers.TRACE_ID_KEY);
         MDC.remove(Tracers.TRACE_SAMPLED_KEY);
         MDC.remove(Tracers.REQUEST_ID_KEY);


### PR DESCRIPTION
## Before this PR
Profiles of a service showed many `java.lang.ThreadLocal$ThreadLocalMap$Entry` allocations in the `Tracer$UnsampledDetachedSpan.childSpan` read path, as threads using `Tracers.wrapWithNewTrace` had previously removed the thread local entry.
```
    com.palantir.tracing.Tracer$UnsampledDetachedSpan.childSpan(String, TagTranslator, Object, SpanType)
    java.lang.ThreadLocal.get()
    java.lang.ThreadLocal.setInitialValue()
    java.lang.ThreadLocal$ThreadLocalMap.set(ThreadLocal, Object)
```

We can adjust `Tracer#clearCurrentTrace` to set the thread local current trace to null so that the `ThreadLocal$ThreadLocalMap$Entry` is reused in these cases.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Tracer#clearCurrentTrace sets thread local current trace to null

Instead of removing the thread local current trace, we now set it to null to avoid the potentially expensive allocation of ThreadLocal$ThreadLocalMap$Entry when a thread is reused.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

