### PR TITLE
Annotate `DetachedSpan.completeAndStartChild` with `@Safe`

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/DetachedSpan.java
+++ b/tracing/src/main/java/com/palantir/tracing/DetachedSpan.java
@@ -107,7 +107,7 @@ public interface DetachedSpan extends Detached {
     }
 
     @MustBeClosed
-    default CloseableSpan completeAndStartChild(String operationName) {
+    default CloseableSpan completeAndStartChild(@Safe String operationName) {
         return completeAndStartChild(operationName, SpanType.LOCAL);
     }
 


### PR DESCRIPTION
Span names are always safe, this edge-case api was missing
the annotation.

==COMMIT_MSG==
Annotate `DetachedSpan.completeAndStartChild` with `@Safe`
==COMMIT_MSG==

