### PR TITLE
Remove Tracer#logClearingTrace()

### DIFF
--- a/changelog/@unreleased/pr-947.v2.yml
+++ b/changelog/@unreleased/pr-947.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Remove Tracer#logClearingTrace()
+  links:
+  - https://github.com/palantir/tracing-java/pull/947

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -909,19 +909,9 @@ public final class Tracer {
 
     @VisibleForTesting
     static void clearCurrentTrace() {
-        logClearingTrace();
         currentTrace.set(null);
         MDC.remove(Tracers.TRACE_ID_KEY);
         MDC.remove(Tracers.TRACE_SAMPLED_KEY);
         MDC.remove(Tracers.REQUEST_ID_KEY);
-    }
-
-    private static void logClearingTrace() {
-        if (log.isDebugEnabled()) {
-            log.debug("Clearing current trace", SafeArg.of("trace", currentTrace.get()));
-            if (log.isTraceEnabled()) {
-                log.trace("Stacktrace at time of clearing trace", new SafeRuntimeException("not a real exception"));
-            }
-        }
     }
 }


### PR DESCRIPTION
## Before this PR
[LOG4J2-3560](https://issues.apache.org/jira/browse/LOG4J2-3560) is triggering significant allocations on calls to `Logger#isDebugEnabled()` such as from `Tracer#logClearingTrace()`

https://github.com/palantir/tracing-java/blob/e7da94d771d531752f377c3195ceb9b54b3027d3/tracing/src/main/java/com/palantir/tracing/Tracer.java#L911-L926

Long term upstream fix for log4j is proposed as https://github.com/apache/logging-log4j2/pull/974 ; however, we may want to consider removing `Tracer#logClearingTrace()` in the interim as it impacts services that heavily utilize tracing, such as [timelock & atlasdb's `AwaitingLeadershipProxy`](https://github.com/palantir/atlasdb/blob/31f015c747daffc57499dad665ba0c56a0f60596/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java#L102-L157)


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove Tracer#logClearingTrace()
==COMMIT_MSG==

## Possible downsides?
We lose the debug & trace logging @tpetracca added in https://github.com/palantir/tracing-java/pull/678 though I don't think this is used often if ever.

