### PR TITLE
Tracer avoids allocating Optional for requestId

### DIFF
--- a/changelog/@unreleased/pr-948.v2.yml
+++ b/changelog/@unreleased/pr-948.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Tracer avoids allocating Optional for requestId
+  links:
+  - https://github.com/palantir/tracing-java/pull/948

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -30,6 +30,7 @@ import com.palantir.tracing.api.SpanType;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * Represents a trace as an ordered list of non-completed spans. Supports adding and removing of spans. This class is
@@ -73,7 +74,7 @@ public abstract class Trace {
     final OpenSpan startSpan(String operation, SpanType type) {
         Optional<OpenSpan> prevState = top();
         final OpenSpan span;
-        // Avoid lambda allocation in hot paths
+        //noinspection OptionalIsPresent - Avoid lambda allocation in hot paths
         if (prevState.isPresent()) {
             span = OpenSpan.of(
                     operation,
@@ -119,14 +120,15 @@ public abstract class Trace {
     }
 
     /**
-     * The request identifier of this trace.
-     *
+     * The request identifier of this trace, or null if undefined.
+     * <p>
      * The request identifier is an implementation detail of this tracing library. A new identifier is generated
      * each time a new trace is created with a SERVER_INCOMING root span. This is a convenience in order to
      * distinguish between requests with the same traceId.
      */
-    final Optional<String> getRequestId() {
-        return Optional.ofNullable(traceState.requestId());
+    @Nullable
+    final String maybeGetRequestId() {
+        return traceState.requestId();
     }
 
     /**

--- a/tracing/src/main/java/com/palantir/tracing/TraceState.java
+++ b/tracing/src/main/java/com/palantir/tracing/TraceState.java
@@ -61,7 +61,7 @@ final class TraceState implements Serializable {
 
     /**
      * The request identifier of this trace.
-     *
+     * <p>
      * The request identifier is an implementation detail of this tracing library. A new identifier is generated
      * each time a new trace is created with a SERVER_INCOMING root span. This is a convenience in order to
      * distinguish between requests with the same traceId.


### PR DESCRIPTION
## Before this PR
Lots of `Optional` allocations from `Tracer` `requestId`
![image](https://user-images.githubusercontent.com/54594/180594766-75fe31c7-2371-4281-a79b-1b2da735a4fd.png)


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Tracer avoids allocating Optional for requestId
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

