### PR TITLE
Add enable flag to closeable tracers

### DIFF
--- a/changelog/@unreleased/pr-986.v2.yml
+++ b/changelog/@unreleased/pr-986.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add enable flag to closeable tracers
+  links:
+  - https://github.com/palantir/tracing-java/pull/986

--- a/tracing/src/main/java/com/palantir/tracing/CloseableTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/CloseableTracer.java
@@ -80,6 +80,73 @@ public class CloseableTracer implements AutoCloseable {
         return new TaggedCloseableTracer<>(translator, data);
     }
 
+    /**
+     * Opens a new {@link SpanType#LOCAL LOCAL} span for this thread's call trace, labeled with the provided operation.
+     */
+    public static CloseableTracer startSpan(@Safe String operation, boolean enable) {
+        if (!enable) {
+            return INSTANCE;
+        }
+
+        return startSpan(operation);
+    }
+
+    /**
+     * Opens a new {@link SpanType#LOCAL LOCAL} span for this thread's call trace, labeled with the provided operation.
+     */
+    public static CloseableTracer startSpan(
+            @Safe String operation, boolean enable, @Safe Map<String, String> metadata) {
+        if (!enable) {
+            return INSTANCE;
+        }
+
+        return startSpan(operation, metadata);
+    }
+
+    /**
+     * Opens a new span for this thread's call trace with the provided {@link SpanType}, labeled with the provided
+     * operation.
+     *
+     * <p>If you need to a span that may complete on another thread, use {@link DetachedSpan#start} instead.
+     */
+    public static CloseableTracer startSpan(@Safe String operation, boolean enable, SpanType spanType) {
+        if (!enable) {
+            return INSTANCE;
+        }
+
+        return startSpan(operation, spanType);
+    }
+
+    /**
+     * Opens a new span for this thread's call trace with the provided {@link SpanType}, labeled with the provided
+     * operation. Equivalent to {@link #startSpan(String, TagTranslator, Object, SpanType)} with {@link SpanType#LOCAL}.
+     *
+     * <p>If you need to a span that may complete on another thread, use {@link DetachedSpan#start} instead.
+     */
+    public static <T> CloseableTracer startSpan(
+            @Safe String operation, boolean enable, TagTranslator<? super T> translator, T data) {
+        if (!enable) {
+            return INSTANCE;
+        }
+
+        return startSpan(operation, translator, data);
+    }
+
+    /**
+     * Opens a new span for this thread's call trace with the provided {@link SpanType}, labeled with the provided
+     * operation.
+     *
+     * <p>If you need to a span that may complete on another thread, use {@link DetachedSpan#start} instead.
+     */
+    public static <T> CloseableTracer startSpan(
+            @Safe String operation, boolean enable, TagTranslator<? super T> translator, T data, SpanType spanType) {
+        if (!enable) {
+            return INSTANCE;
+        }
+
+        return startSpan(operation, translator, data, spanType);
+    }
+
     @Override
     public void close() {
         Tracer.fastCompleteSpan();

--- a/tracing/src/test/java/com/palantir/tracing/CloseableTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/CloseableTracerTest.java
@@ -110,4 +110,22 @@ public final class CloseableTracerTest {
             Tracer.unsubscribe(name);
         }
     }
+
+    @Test
+    public void startsAndClosesSpanIfEnabled() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("foo", true)) {
+            OpenSpan openSpan = Tracer.copyTrace().get().top().get();
+            assertThat(openSpan.getOperation()).isEqualTo("foo");
+            assertThat(openSpan.type()).isEqualTo(SpanType.LOCAL);
+        }
+        assertThat(Tracer.getAndClearTrace().top()).isEmpty();
+    }
+
+    @Test
+    public void doesNotTraceIfDisabled() {
+        try (CloseableTracer tracer = CloseableTracer.startSpan("foo", false)) {
+            assertThat(Tracer.copyTrace()).isEmpty();
+        }
+        assertThat(Tracer.getAndClearTrace().top()).isEmpty();
+    }
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Modifying `CloseableTracer`s to be conditionally enabled is impossible.

```
try (CloseableTracer trace = CloseableTracer.startSpan("foo")) {
   ...
}
```

would have to be written (e.g. when using logger setting to control trace levels):

```
boolean enableTracing = log.isDebugEnabled();

try {
   if (enableTracing) {
      Tracer.fastStartSpan("foo");
   }
   ...
} finally {
    if (enableTracing) {
        Tracer.fastCompleteSpan();
    }
}
```

which makes tracing mix with the actual code.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add enable flag to closeable tracers
==COMMIT_MSG==

This enables the following code:

```
try (CloseableTracer trace = CloseableTracer.startSpan("foo", log.isDebugEnabled())) {
   ...
}
```

## Possible downsides?

Happy to discuss alternative arg ordering/method naming (should it be `startSpanIf` instead? Should the boolean be first?). The reasoning for the ordering was to keep the operation first for readability, but to keep the flag in a consistent place across overloads.
<!-- Please describe any way users could be negatively affected by this PR. -->

