### PR TITLE
Log at debug when `completeSpan` methods are used with no active trace

### DIFF
--- a/changelog/@unreleased/pr-1016.v2.yml
+++ b/changelog/@unreleased/pr-1016.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Log at debug when `completeSpan` methods are used with no active trace
+  links:
+  - https://github.com/palantir/tracing-java/pull/1016

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -640,6 +640,11 @@ public final class Tracer {
             if (trace.isObservable()) {
                 completeSpanAndNotifyObservers(span, tag, state, trace.getTraceId());
             }
+        } else if (log.isDebugEnabled()) {
+            log.debug(
+                    "Attempted to complete spans when there is no active Trace. This may be the "
+                            + "result of calling completeSpan more times than startSpan",
+                    new SafeRuntimeException("not a real exception"));
         }
     }
 
@@ -671,6 +676,12 @@ public final class Tracer {
     public static Optional<Span> completeSpan(@Safe Map<String, String> metadata) {
         Trace trace = currentTrace.get();
         if (trace == null) {
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Attempted to complete spans when there is no active Trace. This may be the "
+                                + "result of calling completeSpan more times than startSpan",
+                        new SafeRuntimeException("not a real exception"));
+            }
             return Optional.empty();
         }
         Optional<Span> maybeSpan = popCurrentSpan(trace)


### PR DESCRIPTION
Such states suggest that a bug has occurred closing more spans than were opened.

==COMMIT_MSG==
Log at debug when `completeSpan` methods are used with no active trace
==COMMIT_MSG==

