### PR TITLE
Use CloseableTracer in DeferredTracer

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -38,6 +38,16 @@ acceptedBreaks:
     - code: "java.method.addedToInterface"
       new: "method com.palantir.tracing.CloseableSpan com.palantir.tracing.DetachedSpan::attach()"
       justification: "DetachedSpan is not meant for external implementations"
+  "6.18.0":
+    com.palantir.tracing:tracing:
+    - code: "java.class.nowAbstract"
+      old: "class com.palantir.tracing.CloseableTracer"
+      new: "class com.palantir.tracing.CloseableTracer"
+      justification: "CloseableTracer should not have external implementations"
+    - code: "java.method.nowAbstract"
+      old: "method void com.palantir.tracing.CloseableTracer::close()"
+      new: "method void com.palantir.tracing.CloseableTracer::close()"
+      justification: "CloseableTracer should not have external implementations"
   "6.3.0":
     com.palantir.tracing:tracing:
     - code: "java.method.removed"

--- a/changelog/@unreleased/pr-1160.v2.yml
+++ b/changelog/@unreleased/pr-1160.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: '`DeferredTracer` can now be used in a try-with-resources block.'
+  links:
+  - https://github.com/palantir/tracing-java/pull/1160

--- a/tracing/src/main/java/com/palantir/tracing/CloseableTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/CloseableTracer.java
@@ -28,7 +28,7 @@ import java.util.Map;
 public class CloseableTracer implements AutoCloseable {
     private static final CloseableTracer INSTANCE = new CloseableTracer();
 
-    private CloseableTracer() {}
+    CloseableTracer() {}
 
     /**
      * Opens a new {@link SpanType#LOCAL LOCAL} span for this thread's call trace, labeled with the provided operation.
@@ -81,6 +81,7 @@ public class CloseableTracer implements AutoCloseable {
     }
 
     @Override
+    @SuppressWarnings("DesignForExtension")
     public void close() {
         Tracer.fastCompleteSpan();
     }

--- a/tracing/src/test/java/com/palantir/tracing/DeferredTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/DeferredTracerTest.java
@@ -50,7 +50,7 @@ public class DeferredTracerTest {
 
         assertThat(Tracer.getTraceId()).isEqualTo("someOtherTraceId");
 
-        try (CloseableTracer tracer = deserialized.withTrace()) {
+        try (CloseableTracer tracer = deserialized.startSpan()) {
             assertThat(Tracer.getTraceId()).isEqualTo("defaultTraceId");
         }
 


### PR DESCRIPTION
## Changes in this PR
- Make `DeferredTracer.withTrace()` public so `DeferredTracer` can be used in try-with-resources blocks. This supports for more flexible uses (ex. non-final variables) and allows users to avoid allocations.
- Modify `DeferredTracer` to use `CloseableTracer` instead of it's separate `CloseableTrace` interface. This is a better API for users because there is a single `CloseableTracer` type. Ideally this would be an interface instead of a concrete class, but we can't break the ABI.
