### PR TITLE
Enable creating detached span with specified request id

### DIFF
--- a/changelog/@unreleased/pr-1248.v2.yml
+++ b/changelog/@unreleased/pr-1248.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Enable creating detached span with specified request id
+  links:
+  - https://github.com/palantir/tracing-java/pull/1248

--- a/tracing/src/main/java/com/palantir/tracing/DetachedSpan.java
+++ b/tracing/src/main/java/com/palantir/tracing/DetachedSpan.java
@@ -19,10 +19,9 @@ package com.palantir.tracing;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.logsafe.Safe;
 import com.palantir.tracing.api.SpanType;
-
-import javax.annotation.CheckReturnValue;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.CheckReturnValue;
 
 /**
  * Span which is not bound to thread state, and can be completed on any other thread.

--- a/tracing/src/main/java/com/palantir/tracing/DetachedSpan.java
+++ b/tracing/src/main/java/com/palantir/tracing/DetachedSpan.java
@@ -19,9 +19,10 @@ package com.palantir.tracing;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.logsafe.Safe;
 import com.palantir.tracing.api.SpanType;
+
+import javax.annotation.CheckReturnValue;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.CheckReturnValue;
 
 /**
  * Span which is not bound to thread state, and can be completed on any other thread.
@@ -84,6 +85,23 @@ public interface DetachedSpan extends Detached {
             @Safe String operation,
             SpanType type) {
         return Tracer.detachInternal(observability, traceId, forUserAgent, parentSpanId, operation, type);
+    }
+
+    /**
+     * Marks the beginning of a span, which you can {@link #complete} on any other thread.
+     *
+     * @see DetachedSpan#start(String)
+     */
+    @CheckReturnValue
+    static DetachedSpan start(
+            Observability observability,
+            String traceId,
+            Optional<String> requestId,
+            Optional<String> forUserAgent,
+            Optional<String> parentSpanId,
+            @Safe String operation,
+            SpanType type) {
+        return Tracer.detachInternal(observability, traceId, requestId, forUserAgent, parentSpanId, operation, type);
     }
 
     /**


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Enable creating detached span with specified request id
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

