### PR TITLE
Provide an API to access the detached trace associated with an exchange

### DIFF
--- a/changelog/@unreleased/pr-1287.v2.yml
+++ b/changelog/@unreleased/pr-1287.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Provide an API to access the detached trace associated with an exchange
+  links:
+  - https://github.com/palantir/tracing-java/pull/1287

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracingAttachments.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracingAttachments.java
@@ -38,6 +38,11 @@ public final class TracingAttachments {
      */
     static final AttachmentKey<DetachedSpan> REQUEST_SPAN = AttachmentKey.create(DetachedSpan.class);
 
+    /**
+     * Gets the {@link Detached} trace state which represents the top-level request being processed. This may
+     * be used to apply thread state to code executing outside traced handlers, exchange completion
+     * listeners, for example.
+     */
     @Nullable
     public static Detached requestTrace(HttpServerExchange exchange) {
         return exchange.getAttachment(REQUEST_SPAN);

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracingAttachments.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracingAttachments.java
@@ -16,7 +16,11 @@
 
 package com.palantir.tracing.undertow;
 
+import com.palantir.tracing.Detached;
+import com.palantir.tracing.DetachedSpan;
+import io.undertow.server.HttpServerExchange;
 import io.undertow.util.AttachmentKey;
+import javax.annotation.Nullable;
 
 /** Provides public tracing {@link AttachmentKey attachment keys}. */
 public final class TracingAttachments {
@@ -26,6 +30,18 @@ public final class TracingAttachments {
 
     /** Attachment providing the request identifier. */
     public static final AttachmentKey<String> REQUEST_ID = AttachmentKey.create(String.class);
+
+    /**
+     * Detached span object representing the entire request including asynchronous components.
+     * This is intentionally not public, we expose only the {@link Detached} component which critically does not
+     * include {@link DetachedSpan#complete()} APIs.
+     */
+    static final AttachmentKey<DetachedSpan> REQUEST_SPAN = AttachmentKey.create(DetachedSpan.class);
+
+    @Nullable
+    public static Detached requestTrace(HttpServerExchange exchange) {
+        return exchange.getAttachment(REQUEST_SPAN);
+    }
 
     private TracingAttachments() {}
 }

--- a/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedOperationHandlerTest.java
+++ b/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedOperationHandlerTest.java
@@ -198,6 +198,12 @@ public class TracedOperationHandlerTest {
     }
 
     @Test
+    public void setsDetachedTrace() throws Exception {
+        handler.handleRequest(exchange);
+        assertThat(TracingAttachments.requestTrace(exchange)).isNotNull();
+    }
+
+    @Test
     public void completesSpanEvenIfDelegateThrows() throws Exception {
         doThrow(new RuntimeException()).when(delegate).handleRequest(any());
         try {

--- a/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedOperationHandlerTest.java
+++ b/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedOperationHandlerTest.java
@@ -118,7 +118,7 @@ public class TracedOperationHandlerTest {
 
         handler.handleRequest(exchange);
         // Since we're not running a full request, the completion handler cannot execute normally.
-        exchange.getAttachment(UndertowTracing.REQUEST_SPAN).complete();
+        exchange.getAttachment(TracingAttachments.REQUEST_SPAN).complete();
         verify(observer, times(2)).consume(spanCaptor.capture());
         List<Span> spans = spanCaptor.getAllValues();
         assertThat(spans).hasSize(2);
@@ -134,7 +134,7 @@ public class TracedOperationHandlerTest {
         setUserAgent("userAgent");
         handler.handleRequest(exchange);
 
-        DetachedSpan detachedSpan = exchange.getAttachment(UndertowTracing.REQUEST_SPAN);
+        DetachedSpan detachedSpan = exchange.getAttachment(TracingAttachments.REQUEST_SPAN);
         assertThat(InternalTracers.getForUserAgent(detachedSpan)).contains("userAgent");
     }
 
@@ -145,7 +145,7 @@ public class TracedOperationHandlerTest {
         setFetchUserAgent("fetchUserAgent");
         handler.handleRequest(exchange);
 
-        DetachedSpan detachedSpan = exchange.getAttachment(UndertowTracing.REQUEST_SPAN);
+        DetachedSpan detachedSpan = exchange.getAttachment(TracingAttachments.REQUEST_SPAN);
         assertThat(InternalTracers.getForUserAgent(detachedSpan)).contains("fetchUserAgent");
     }
 
@@ -157,7 +157,7 @@ public class TracedOperationHandlerTest {
         setForUserAgent("forUserAgent");
         handler.handleRequest(exchange);
 
-        DetachedSpan detachedSpan = exchange.getAttachment(UndertowTracing.REQUEST_SPAN);
+        DetachedSpan detachedSpan = exchange.getAttachment(TracingAttachments.REQUEST_SPAN);
         assertThat(InternalTracers.getForUserAgent(detachedSpan)).contains("forUserAgent");
     }
 


### PR DESCRIPTION
==COMMIT_MSG==
Provide an API to access the detached trace associated with an exchange
==COMMIT_MSG==

Alternative to #1288 which provides more direct access to the underlying `Detached` tracing exchange attachment. Uses can be more obvious as they interact directly with tracing.
