### PR TITLE
broaden the requestTrace attachment accessor

### DIFF
--- a/changelog/@unreleased/pr-1297.v2.yml
+++ b/changelog/@unreleased/pr-1297.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: broaden the requestTrace attachment accessor
+  links:
+  - https://github.com/palantir/tracing-java/pull/1297

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracingAttachments.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracingAttachments.java
@@ -54,7 +54,7 @@ public final class TracingAttachments {
      */
     @Nullable
     public static Detached requestTrace(HttpServerExchange exchange) {
-        return exchange.getAttachment(REQUEST_SPAN);
+        return exchange.getAttachment(REQUEST_DETACHED_TRACE);
     }
 
     private TracingAttachments() {}

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracingAttachments.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracingAttachments.java
@@ -19,7 +19,6 @@ package com.palantir.tracing.undertow;
 import com.palantir.tracing.Detached;
 import com.palantir.tracing.DetachedSpan;
 import io.undertow.server.HttpServerExchange;
-import io.undertow.util.Attachable;
 import io.undertow.util.AttachmentKey;
 import javax.annotation.Nullable;
 
@@ -40,25 +39,21 @@ public final class TracingAttachments {
     static final AttachmentKey<DetachedSpan> REQUEST_SPAN = AttachmentKey.create(DetachedSpan.class);
 
     /**
+     * The {@link Detached} trace state which represents the top-level request being processed. This may
+     * be used to apply thread state to code executing outside traced handlers, exchange completion
+     * listeners, for example.
+     */
+    @SuppressWarnings("unchecked")
+    public static final AttachmentKey<Detached> REQUEST_DETACHED_TRACE =
+            (AttachmentKey<Detached>) (AttachmentKey<?>) REQUEST_SPAN;
+
+    /**
      * Gets the {@link Detached} trace state which represents the top-level request being processed. This may
      * be used to apply thread state to code executing outside traced handlers, exchange completion
      * listeners, for example.
      */
     @Nullable
     public static Detached requestTrace(HttpServerExchange exchange) {
-        return requestTrace((Attachable) exchange);
-    }
-
-    /**
-     * Gets the {@link Detached} trace state which represents the top-level request being processed. This may
-     * be used to apply thread state to code executing outside traced handlers, exchange completion
-     * listeners, for example.
-     * <p>
-     * Note that this intentionally returns a {@link Detached} rather than {@link DetachedSpan} because
-     * this framework is responsible for closing the root request span.
-     */
-    @Nullable
-    public static Detached requestTrace(Attachable exchange) {
         return exchange.getAttachment(REQUEST_SPAN);
     }
 

--- a/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracingAttachments.java
+++ b/tracing-undertow/src/main/java/com/palantir/tracing/undertow/TracingAttachments.java
@@ -19,6 +19,7 @@ package com.palantir.tracing.undertow;
 import com.palantir.tracing.Detached;
 import com.palantir.tracing.DetachedSpan;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Attachable;
 import io.undertow.util.AttachmentKey;
 import javax.annotation.Nullable;
 
@@ -45,6 +46,19 @@ public final class TracingAttachments {
      */
     @Nullable
     public static Detached requestTrace(HttpServerExchange exchange) {
+        return requestTrace((Attachable) exchange);
+    }
+
+    /**
+     * Gets the {@link Detached} trace state which represents the top-level request being processed. This may
+     * be used to apply thread state to code executing outside traced handlers, exchange completion
+     * listeners, for example.
+     * <p>
+     * Note that this intentionally returns a {@link Detached} rather than {@link DetachedSpan} because
+     * this framework is responsible for closing the root request span.
+     */
+    @Nullable
+    public static Detached requestTrace(Attachable exchange) {
         return exchange.getAttachment(REQUEST_SPAN);
     }
 

--- a/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedOperationHandlerTest.java
+++ b/tracing-undertow/src/test/java/com/palantir/tracing/undertow/TracedOperationHandlerTest.java
@@ -201,6 +201,8 @@ public class TracedOperationHandlerTest {
     public void setsDetachedTrace() throws Exception {
         handler.handleRequest(exchange);
         assertThat(TracingAttachments.requestTrace(exchange)).isNotNull();
+        assertThat(exchange.getAttachment(TracingAttachments.REQUEST_DETACHED_TRACE))
+                .isNotNull();
     }
 
     @Test


### PR DESCRIPTION
==COMMIT_MSG==
broaden the requestTrace attachment accessor
==COMMIT_MSG==

This allows us to pull the attachment value from one of the many types which wrap an HttpServerExchange and delegate to its attachments, for example `WebSocketHttpExchange` (not Attachable) and `ServerSentEventConnection` (Attachable). 