### PR TITLE
add a Parent-Request-Id header

### DIFF
--- a/changelog/@unreleased/pr-1365.v2.yml
+++ b/changelog/@unreleased/pr-1365.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: add a Parent-Request-Id header
+  links:
+  - https://github.com/palantir/tracing-java/pull/1365

--- a/tracing-api/src/main/java/com/palantir/tracing/api/TraceHttpHeaders.java
+++ b/tracing-api/src/main/java/com/palantir/tracing/api/TraceHttpHeaders.java
@@ -39,4 +39,14 @@ public interface TraceHttpHeaders {
      */
     @Deprecated
     String ORIGINATING_SPAN_ID = "X-OrigSpanId";
+
+    /**
+     * For traces initiated with span type {@link SpanType#SERVER_INCOMING},
+     * this header will be set to the requestId generated for that trace.
+     *
+     * Inclusion of this header on outbound requests allows receivers to potentially observe the operations
+     * for the direct parent of a request received at an endpoint without the need to observe all operations
+     * in the entire trace.
+     */
+    String PARENT_REQUEST_ID = "Parent-Request-Id";
 }

--- a/tracing-api/src/main/java/com/palantir/tracing/api/TraceHttpHeaders.java
+++ b/tracing-api/src/main/java/com/palantir/tracing/api/TraceHttpHeaders.java
@@ -16,7 +16,7 @@
 
 package com.palantir.tracing.api;
 
-/** Zipkin-compatible HTTP header names. */
+/** HTTP header names used by tracing-java. */
 public interface TraceHttpHeaders {
     String TRACE_ID = "X-B3-TraceId";
     /**
@@ -41,12 +41,10 @@ public interface TraceHttpHeaders {
     String ORIGINATING_SPAN_ID = "X-OrigSpanId";
 
     /**
-     * For traces initiated with span type {@link SpanType#SERVER_INCOMING},
-     * this header will be set to the requestId generated for that trace.
-     *
-     * Inclusion of this header on outbound requests allows receivers to potentially observe the operations
-     * for the direct parent of a request received at an endpoint without the need to observe all operations
-     * in the entire trace.
+     * The {@code Parent-Request-Id} header represents the requestId of the caller, if present.
+     * This provides a direct causal connection between requests up a call stack. This can be an advantage
+     * over traceId which provides a broad set of data without information to understand the call
+     * pathing unless spans are sampled.
      */
     String PARENT_REQUEST_ID = "Parent-Request-Id";
 }

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -278,6 +278,10 @@ public final class Tracers {
         if (forUserAgent.isPresent()) {
             tracingHeadersEnrichingFunction.addHeader(TraceHttpHeaders.FOR_USER_AGENT, forUserAgent.get(), state);
         }
+        Optional<String> requestId = traceMetadata.getRequestId();
+        if (requestId.isPresent()) {
+            tracingHeadersEnrichingFunction.addHeader(TraceHttpHeaders.PARENT_REQUEST_ID, requestId.get(), state);
+        }
     }
 
     private static final class ListenableFutureSpanListener implements Runnable {

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -907,6 +907,28 @@ public final class TracersTest {
                         "X-B3-TraceId", "defaultTraceId",
                         "X-B3-Sampled", "1"));
         assertThat(headers).containsKey("X-B3-SpanId");
+        // no requestId set when span type is local
+        assertThat(headers).doesNotContainKey("Parent-Request-Id");
+    }
+
+    @Test
+    public void testAddTracingHeaders_addsParentRequestId() {
+        // need to set span type to SERVER_INCOMING to generate a requestId
+        Tracer.initTraceWithSpan(
+                Observability.SAMPLE,
+                "defaultTraceId",
+                Optional.of("forUserAgent"),
+                "rootOperation",
+                SpanType.SERVER_INCOMING);
+
+        Map<String, String> headers = new HashMap<>();
+        TracingHeadersEnrichingFunction<Map<String, String>> enrichingFunction =
+                (headerName, headerValue, state) -> state.put(headerName, headerValue);
+
+        Tracers.addTracingHeaders(headers, enrichingFunction);
+
+        assertThat(headers).containsKey("Parent-Request-Id");
+        assertThat(headers.get("Parent-Request-Id")).isNotBlank();
     }
 
     private static Callable<Void> newTraceExpectingCallable(String expectedOperation) {

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -920,6 +920,11 @@ public final class TracersTest {
                 Optional.of("forUserAgent"),
                 "rootOperation",
                 SpanType.SERVER_INCOMING);
+        Optional<TraceMetadata> traceMetadata = Tracer.maybeGetTraceMetadata();
+        assertThat(traceMetadata).isPresent();
+
+        Optional<String> requestId = traceMetadata.get().getRequestId();
+        assertThat(requestId).isPresent();
 
         Map<String, String> headers = new HashMap<>();
         TracingHeadersEnrichingFunction<Map<String, String>> enrichingFunction =
@@ -927,8 +932,7 @@ public final class TracersTest {
 
         Tracers.addTracingHeaders(headers, enrichingFunction);
 
-        assertThat(headers).containsKey("Parent-Request-Id");
-        assertThat(headers.get("Parent-Request-Id")).isNotBlank();
+        assertThat(headers).containsEntry("Parent-Request-Id", requestId.get());
     }
 
     private static Callable<Void> newTraceExpectingCallable(String expectedOperation) {


### PR DESCRIPTION
## Before this PR
Traces created with a span type of `SERVER_INCOMING` generate a requestId, which is useful for observing operations on a service related to handling a particular inbound request. However, that requestId is local to the service itself, and doesn't allow for easily following RPC call chains in observability data. While the traceId does allow for this, it can sometimes be overly noisy and doesn't allow for easily tracing through RPC calls themselves.

## After this PR
add a Parent-Request-Id header

This provides better observability for RPC call chains by having callers include their own generated requestId (if one exists) on new outbound requests. Receivers can log the `Parent-Request-Id` header value. This should allow for observing the operations that generated a request to an endpoint by following `Parent-Request-Id` pointers backwards, without needing to view observability data for the entire traceId, which may be very large.

==COMMIT_MSG==
add a Parent-Request-Id header
==COMMIT_MSG==

## Possible downsides?
Extra header means more bytes on the wire, but should be small.

