### PR TITLE
Fix parameterized test tracing wrongly accumulating spans

### DIFF
--- a/changelog/@unreleased/pr-1406.v2.yml
+++ b/changelog/@unreleased/pr-1406.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Fix issue with test tracing snapshot accumulating spans in parameterized
+    testing context. Existing parameterized tests will fail due to extra entries in
+    the expected spans that were wrongly added previously.
+  links:
+  - https://github.com/palantir/tracing-java/pull/1406

--- a/tracing-test-utils/src/main/java/com/palantir/tracing/TestTracingExtension.java
+++ b/tracing-test-utils/src/main/java/com/palantir/tracing/TestTracingExtension.java
@@ -18,7 +18,6 @@ package com.palantir.tracing;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.tracing.api.Serialization;
 import com.palantir.tracing.api.Span;
 import java.nio.file.Files;
@@ -33,6 +32,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,11 +40,16 @@ import org.slf4j.LoggerFactory;
 final class TestTracingExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
 
     private static final Logger log = LoggerFactory.getLogger(TestTracingExtension.class);
+    private static final Namespace TRACING_EXT_NAMESPACE = Namespace.create(TestTracingExtension.class);
+    private static final String SUBSCRIBER_STORE_KEY = "subscriber";
 
     @Override
     public void beforeTestExecution(ExtensionContext context) {
         Tracer.setSampler(AlwaysSampler.INSTANCE);
-        Tracer.subscribe(context.getUniqueId(), new TestTracingSubscriber());
+        TestTracingSubscriber subscriber = context.getStore(TRACING_EXT_NAMESPACE)
+                .getOrComputeIfAbsent(
+                        SUBSCRIBER_STORE_KEY, _k -> new TestTracingSubscriber(), TestTracingSubscriber.class);
+        Tracer.subscribe(context.getUniqueId(), subscriber);
 
         // TODO(dfox): sample can be modified by other code, we should be try ensure that the trace is always sampled
         // for the lifetime of the test
@@ -55,9 +60,9 @@ final class TestTracingExtension implements BeforeTestExecutionCallback, AfterTe
     @Override
     public void afterTestExecution(ExtensionContext context) throws Exception {
         String name = testName(context);
-        if (!(Tracer.unsubscribe(context.getUniqueId()) instanceof TestTracingSubscriber subscriber)) {
-            throw new SafeIllegalStateException("Expecting TestTracingSubscriber");
-        }
+        Tracer.unsubscribe(context.getUniqueId());
+        TestTracingSubscriber subscriber =
+                context.getStore(TRACING_EXT_NAMESPACE).remove(SUBSCRIBER_STORE_KEY, TestTracingSubscriber.class);
 
         Path outputPath = getOutputPath(name);
         Path snapshotFile = Paths.get("src/test/resources/tracing").resolve(name + ".log");

--- a/tracing-test-utils/src/main/java/com/palantir/tracing/TestTracingExtension.java
+++ b/tracing-test-utils/src/main/java/com/palantir/tracing/TestTracingExtension.java
@@ -18,6 +18,7 @@ package com.palantir.tracing;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.tracing.api.Serialization;
 import com.palantir.tracing.api.Span;
 import java.nio.file.Files;
@@ -39,12 +40,11 @@ import org.slf4j.LoggerFactory;
 final class TestTracingExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
 
     private static final Logger log = LoggerFactory.getLogger(TestTracingExtension.class);
-    private final TestTracingSubscriber subscriber = new TestTracingSubscriber();
 
     @Override
     public void beforeTestExecution(ExtensionContext context) {
         Tracer.setSampler(AlwaysSampler.INSTANCE);
-        Tracer.subscribe(context.getUniqueId(), subscriber);
+        Tracer.subscribe(context.getUniqueId(), new TestTracingSubscriber());
 
         // TODO(dfox): sample can be modified by other code, we should be try ensure that the trace is always sampled
         // for the lifetime of the test
@@ -55,7 +55,9 @@ final class TestTracingExtension implements BeforeTestExecutionCallback, AfterTe
     @Override
     public void afterTestExecution(ExtensionContext context) throws Exception {
         String name = testName(context);
-        Tracer.unsubscribe(context.getUniqueId());
+        if (!(Tracer.unsubscribe(context.getUniqueId()) instanceof TestTracingSubscriber subscriber)) {
+            throw new SafeIllegalStateException("Expecting TestTracingSubscriber");
+        }
 
         Path outputPath = getOutputPath(name);
         Path snapshotFile = Paths.get("src/test/resources/tracing").resolve(name + ".log");

--- a/tracing-test-utils/src/main/java/com/palantir/tracing/TestTracingExtension.java
+++ b/tracing-test-utils/src/main/java/com/palantir/tracing/TestTracingExtension.java
@@ -40,20 +40,16 @@ import org.slf4j.LoggerFactory;
 final class TestTracingExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
 
     private static final Logger log = LoggerFactory.getLogger(TestTracingExtension.class);
-    private static final Namespace TRACING_EXT_NAMESPACE = Namespace.create(TestTracingExtension.class);
-    private static final String SUBSCRIBER_STORE_KEY = "subscriber";
+    private static final Namespace NAMESPACE = Namespace.create(TestTracingExtension.class);
+    private static final String SUBSCRIBER_KEY = "subscriber";
 
     @Override
     public void beforeTestExecution(ExtensionContext context) {
+        TestTracingSubscriber subscriber = context.getStore(NAMESPACE)
+                .getOrComputeIfAbsent(SUBSCRIBER_KEY, _k -> new TestTracingSubscriber(), TestTracingSubscriber.class);
         Tracer.setSampler(AlwaysSampler.INSTANCE);
-        TestTracingSubscriber subscriber = context.getStore(TRACING_EXT_NAMESPACE)
-                .getOrComputeIfAbsent(
-                        SUBSCRIBER_STORE_KEY, _k -> new TestTracingSubscriber(), TestTracingSubscriber.class);
         Tracer.subscribe(context.getUniqueId(), subscriber);
 
-        // TODO(dfox): sample can be modified by other code, we should be try ensure that the trace is always sampled
-        // for the lifetime of the test
-        // TODO(dfox): clear existing tracing??
         // TODO(forozco): cleanup stale snapshots from outdated tests cases/classes
     }
 
@@ -62,7 +58,7 @@ final class TestTracingExtension implements BeforeTestExecutionCallback, AfterTe
         String name = testName(context);
         Tracer.unsubscribe(context.getUniqueId());
         TestTracingSubscriber subscriber =
-                context.getStore(TRACING_EXT_NAMESPACE).remove(SUBSCRIBER_STORE_KEY, TestTracingSubscriber.class);
+                context.getStore(NAMESPACE).remove(SUBSCRIBER_KEY, TestTracingSubscriber.class);
 
         Path outputPath = getOutputPath(name);
         Path snapshotFile = Paths.get("src/test/resources/tracing").resolve(name + ".log");

--- a/tracing-test-utils/src/test/resources/tracing/TestTracingExtensionDemo/handles_trace_with_single_root_span/foo 2 bar 2.log
+++ b/tracing-test-utils/src/test/resources/tracing/TestTracingExtensionDemo/handles_trace_with_single_root_span/foo 2 bar 2.log
@@ -1,8 +1,3 @@
-{"traceId":"fc66359b4cf2cc43","parentSpanId":"65752bf490a47a30","spanId":"55d0ab448795fc97","operation":"nested","startTimeMicroSeconds":1567076544357605,"durationNanoSeconds":93468089,"metadata":{}}
-{"traceId":"fc66359b4cf2cc43","parentSpanId":"07d4220dd5e520fc","spanId":"65752bf490a47a30","operation":"first","startTimeMicroSeconds":1567076544254098,"durationNanoSeconds":207848123,"metadata":{}}
-{"traceId":"fc66359b4cf2cc43","parentSpanId":"07d4220dd5e520fc","spanId":"f302db3ff71079d0","operation":"second","startTimeMicroSeconds":1567076544461999,"durationNanoSeconds":101253285,"metadata":{}}
-{"traceId":"fc66359b4cf2cc43","parentSpanId":"07d4220dd5e520fc","spanId":"bbbc8cbdf2646378","operation":"third","startTimeMicroSeconds":1567076544563361,"durationNanoSeconds":104430058,"metadata":{}}
-{"traceId":"fc66359b4cf2cc43","parentSpanId":null,"spanId":"07d4220dd5e520fc","operation":"root","startTimeMicroSeconds":1567076544254086,"durationNanoSeconds":413762617,"metadata":{}}
 {"traceId":"f93d913ccb274d5e","parentSpanId":"050b8add2c2b87d1","spanId":"7976952441b0ac82","operation":"nested","startTimeMicroSeconds":1567076544793118,"durationNanoSeconds":95104259,"metadata":{}}
 {"traceId":"f93d913ccb274d5e","parentSpanId":"e6ce3b091602c063","spanId":"050b8add2c2b87d1","operation":"first","startTimeMicroSeconds":1567076544691357,"durationNanoSeconds":208954194,"metadata":{}}
 {"traceId":"f93d913ccb274d5e","parentSpanId":"e6ce3b091602c063","spanId":"2e3e970590f1b45e","operation":"second","startTimeMicroSeconds":1567076544900434,"durationNanoSeconds":101589476,"metadata":{}}

--- a/tracing-test-utils/src/test/resources/tracing/TestTracingExtensionDemo/handles_trace_with_single_root_span/foo 3 bar 3.log
+++ b/tracing-test-utils/src/test/resources/tracing/TestTracingExtensionDemo/handles_trace_with_single_root_span/foo 3 bar 3.log
@@ -1,13 +1,3 @@
-{"traceId":"fc66359b4cf2cc43","parentSpanId":"65752bf490a47a30","spanId":"55d0ab448795fc97","operation":"nested","startTimeMicroSeconds":1567076544357605,"durationNanoSeconds":93468089,"metadata":{}}
-{"traceId":"fc66359b4cf2cc43","parentSpanId":"07d4220dd5e520fc","spanId":"65752bf490a47a30","operation":"first","startTimeMicroSeconds":1567076544254098,"durationNanoSeconds":207848123,"metadata":{}}
-{"traceId":"fc66359b4cf2cc43","parentSpanId":"07d4220dd5e520fc","spanId":"f302db3ff71079d0","operation":"second","startTimeMicroSeconds":1567076544461999,"durationNanoSeconds":101253285,"metadata":{}}
-{"traceId":"fc66359b4cf2cc43","parentSpanId":"07d4220dd5e520fc","spanId":"bbbc8cbdf2646378","operation":"third","startTimeMicroSeconds":1567076544563361,"durationNanoSeconds":104430058,"metadata":{}}
-{"traceId":"fc66359b4cf2cc43","parentSpanId":null,"spanId":"07d4220dd5e520fc","operation":"root","startTimeMicroSeconds":1567076544254086,"durationNanoSeconds":413762617,"metadata":{}}
-{"traceId":"f93d913ccb274d5e","parentSpanId":"050b8add2c2b87d1","spanId":"7976952441b0ac82","operation":"nested","startTimeMicroSeconds":1567076544793118,"durationNanoSeconds":95104259,"metadata":{}}
-{"traceId":"f93d913ccb274d5e","parentSpanId":"e6ce3b091602c063","spanId":"050b8add2c2b87d1","operation":"first","startTimeMicroSeconds":1567076544691357,"durationNanoSeconds":208954194,"metadata":{}}
-{"traceId":"f93d913ccb274d5e","parentSpanId":"e6ce3b091602c063","spanId":"2e3e970590f1b45e","operation":"second","startTimeMicroSeconds":1567076544900434,"durationNanoSeconds":101589476,"metadata":{}}
-{"traceId":"f93d913ccb274d5e","parentSpanId":"e6ce3b091602c063","spanId":"4d2ff23f6260c140","operation":"third","startTimeMicroSeconds":1567076545002165,"durationNanoSeconds":104911496,"metadata":{}}
-{"traceId":"f93d913ccb274d5e","parentSpanId":null,"spanId":"e6ce3b091602c063","operation":"root","startTimeMicroSeconds":1567076544691343,"durationNanoSeconds":415777286,"metadata":{}}
 {"traceId":"9aada2f1810e006c","parentSpanId":"137b240f0ce29196","spanId":"18bc7803589eda48","operation":"nested","startTimeMicroSeconds":1567076545239097,"durationNanoSeconds":93975475,"metadata":{}}
 {"traceId":"9aada2f1810e006c","parentSpanId":"a634e47d1b808b29","spanId":"137b240f0ce29196","operation":"first","startTimeMicroSeconds":1567076545137630,"durationNanoSeconds":205881393,"metadata":{}}
 {"traceId":"9aada2f1810e006c","parentSpanId":"a634e47d1b808b29","spanId":"79ed99549e2ad7da","operation":"second","startTimeMicroSeconds":1567076545343736,"durationNanoSeconds":103896953,"metadata":{}}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
When running test tracing with parameterized tests, the spans accumulate at each iteration leading to confusing traces.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix issue with test tracing snapshot accumulating spans in parameterized testing context. Existing parameterized tests will fail due to extra entries in the expected spans that were wrongly added previously.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

