### PR TITLE
Deprecate TraceMetadata.getParentSpanId

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/TraceMetadata.java
+++ b/tracing/src/main/java/com/palantir/tracing/TraceMetadata.java
@@ -36,7 +36,12 @@ public interface TraceMetadata {
     /** Corresponds to {@link com.palantir.tracing.api.TraceHttpHeaders#SPAN_ID} on outgoing requests. */
     String getSpanId();
 
-    /** Corresponds to {@link com.palantir.tracing.api.TraceHttpHeaders#SPAN_ID} on incoming requests. */
+    /**
+     * Corresponds to {@link com.palantir.tracing.api.TraceHttpHeaders#PARENT_SPAN_ID} which is no longer used.
+     *
+     * @deprecated No longer used
+     */
+    @Deprecated
     Optional<String> getParentSpanId();
 
     /**

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -103,7 +103,7 @@ public final class Tracer {
     }
 
     /**
-     * In the unsampled case, the Trace.Unsampled class doesn't actually store a spanId/parentSpanId stack, so we just
+     * In the unsampled case, the Trace.Unsampled class doesn't actually store a span stack, so we just
      * make one up (just in time). This matches the behaviour of Tracer#startSpan.
      *
      * <p>n.b. this is a bit funky because calling maybeGetTraceMetadata multiple times will return different spanIds
@@ -114,21 +114,13 @@ public final class Tracer {
             return Optional.empty();
         }
 
-        TraceMetadata.Builder builder = TraceMetadata.builder().traceId(trace.getTraceId());
-        String requestId = trace.maybeGetRequestId();
-        if (requestId != null) {
-            builder.requestId(requestId);
-        }
+        OpenSpan span = trace.top().orElse(null);
 
-        if (trace.isObservable()) {
-            return trace.top().map(openSpan -> builder.spanId(openSpan.getSpanId())
-                    .parentSpanId(openSpan.getParentSpanId())
-                    .build());
-        } else {
-            return Optional.of(builder.spanId(Tracers.randomId())
-                    .parentSpanId(Optional.empty())
-                    .build());
-        }
+        return Optional.of(TraceMetadata.builder()
+                .traceId(trace.getTraceState().traceId())
+                .spanId(span != null ? span.getSpanId() : Tracers.randomId())
+                .requestId(Optional.ofNullable(trace.maybeGetRequestId()))
+                .build());
     }
 
     /**


### PR DESCRIPTION
This has been unused since https://github.com/palantir/tracing-java/pull/778. There is no reason that RPC callees need to see more than the current span ID.