### PR TITLE
Remove duplicative trace state passthrough methods

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
@@ -95,7 +95,7 @@ public final class DeferredTracer implements Serializable {
         Optional<Trace> maybeTrace = Tracer.copyTrace();
         if (maybeTrace.isPresent()) {
             Trace trace = maybeTrace.get();
-            this.traceState = trace.getTraceState();
+            this.traceState = trace.traceState();
             this.isObservable = trace.isObservable();
             this.parentSpanId = trace.top().map(OpenSpan::getSpanId).orElse(null);
             this.operation = operation;

--- a/tracing/src/main/java/com/palantir/tracing/InternalTracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/InternalTracers.java
@@ -33,7 +33,7 @@ public final class InternalTracers {
 
     /** Returns requestId of the provided detachedSpan. */
     public static Optional<String> getRequestId(DetachedSpan detachedSpan) {
-        return Optional.ofNullable(Tracer.getRequestId(detachedSpan));
+        return Tracer.getRequestId(detachedSpan);
     }
 
     /**

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -30,7 +30,6 @@ import com.palantir.tracing.api.SpanType;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a trace as an ordered list of non-completed spans. Supports adding and removing of spans. This class is
@@ -110,32 +109,8 @@ public abstract class Trace {
     abstract boolean isObservable();
 
     /** The state of the trace which is stored for each created trace. */
-    final TraceState getTraceState() {
-        return this.traceState;
-    }
-
-    /** The globally unique non-empty identifier for this call trace. */
-    final String getTraceId() {
-        return traceState.traceId();
-    }
-
-    /**
-     * The request identifier of this trace, or null if undefined.
-     * <p>
-     * The request identifier is an implementation detail of this tracing library. A new identifier is generated
-     * each time a new trace is created with a SERVER_INCOMING root span. This is a convenience in order to
-     * distinguish between requests with the same traceId.
-     */
-    @Nullable
-    final String maybeGetRequestId() {
-        return traceState.requestId();
-    }
-
-    /**
-     * The user agent propagated across this trace.
-     */
-    final Optional<String> getForUserAgent() {
-        return Optional.ofNullable(traceState.forUserAgent());
+    final TraceState traceState() {
+        return traceState;
     }
 
     /** Returns a copy of this Trace which can be independently mutated. */
@@ -202,12 +177,12 @@ public abstract class Trace {
 
         @Override
         Trace deepCopy() {
-            return new Sampled(new ArrayDeque<>(stack), getTraceState());
+            return new Sampled(new ArrayDeque<>(stack), traceState());
         }
 
         @Override
         public String toString() {
-            return "Trace{stack=" + stack + ", isObservable=true, state=" + getTraceState() + "}";
+            return "Trace{stack=" + stack + ", isObservable=true, state=" + traceState() + "}";
         }
     }
 
@@ -270,7 +245,7 @@ public abstract class Trace {
 
         @Override
         Trace deepCopy() {
-            return new Unsampled(numberOfSpans, getTraceState());
+            return new Unsampled(numberOfSpans, traceState());
         }
 
         /** Internal validation, this should never fail because {@link #pop()} only decrements positive values. */
@@ -283,7 +258,7 @@ public abstract class Trace {
 
         @Override
         public String toString() {
-            return "Trace{numberOfSpans=" + numberOfSpans + ", isObservable=false, traceState=" + getTraceState() + "}";
+            return "Trace{numberOfSpans=" + numberOfSpans + ", isObservable=false, traceState=" + traceState() + "}";
         }
     }
 }

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -117,9 +117,9 @@ public final class Tracer {
         OpenSpan span = trace.top().orElse(null);
 
         return Optional.of(TraceMetadata.builder()
-                .traceId(trace.getTraceState().traceId())
+                .traceId(trace.traceState().traceId())
                 .spanId(span != null ? span.getSpanId() : Tracers.randomId())
-                .requestId(Optional.ofNullable(trace.maybeGetRequestId()))
+                .requestId(Optional.ofNullable(trace.traceState().requestId()))
                 .build());
     }
 
@@ -327,9 +327,9 @@ public final class Tracer {
             if (maybeOpenSpan == null) {
                 return NopDetached.INSTANCE;
             }
-            return new SampledDetached(trace.getTraceState(), maybeOpenSpan);
+            return new SampledDetached(trace.traceState(), maybeOpenSpan);
         } else {
-            return new UnsampledDetachedSpan(trace.getTraceState(), Optional.empty());
+            return new UnsampledDetachedSpan(trace.traceState(), Optional.empty());
         }
     }
 
@@ -351,12 +351,12 @@ public final class Tracer {
             return null;
         }
 
-        return maybeCurrentTrace.getTraceState();
+        return maybeCurrentTrace.traceState();
     }
 
     private static TraceState getTraceState(@Nullable Trace maybeCurrentTrace, SpanType newSpanType) {
         if (maybeCurrentTrace != null) {
-            return maybeCurrentTrace.getTraceState();
+            return maybeCurrentTrace.traceState();
         }
         return TraceState.of(Tracers.randomId(), getRequestIdForSpan(newSpanType), Optional.empty());
     }
@@ -368,13 +368,12 @@ public final class Tracer {
         return Optional.empty();
     }
 
-    @Nullable
-    static String getRequestId(DetachedSpan detachedSpan) {
+    static Optional<String> getRequestId(DetachedSpan detachedSpan) {
         if (detachedSpan instanceof SampledDetachedSpan sampledDetachedSpan) {
-            return sampledDetachedSpan.traceState.requestId();
+            return Optional.ofNullable(sampledDetachedSpan.traceState.requestId());
         }
         if (detachedSpan instanceof UnsampledDetachedSpan unsampledDetachedSpan) {
-            return unsampledDetachedSpan.traceState.requestId();
+            return Optional.ofNullable(unsampledDetachedSpan.traceState.requestId());
         }
         throw new SafeIllegalStateException("Unknown span type", SafeArg.of("detachedSpan", detachedSpan));
     }
@@ -598,7 +597,8 @@ public final class Tracer {
         if (trace != null) {
             Optional<OpenSpan> span = popCurrentSpan(trace);
             if (trace.isObservable()) {
-                completeSpanAndNotifyObservers(span, tag, state, trace.getTraceId());
+                completeSpanAndNotifyObservers(
+                        span, tag, state, trace.traceState().traceId());
             }
         } else {
             logCompletedWithoutStarted();
@@ -637,7 +637,11 @@ public final class Tracer {
             return Optional.empty();
         }
         Optional<Span> maybeSpan = popCurrentSpan(trace)
-                .map(openSpan -> toSpan(openSpan, MapTagTranslator.INSTANCE, metadata, trace.getTraceId()));
+                .map(openSpan -> toSpan(
+                        openSpan,
+                        MapTagTranslator.INSTANCE,
+                        metadata,
+                        trace.traceState().traceId()));
 
         // Notify subscribers iff trace is observable
         if (maybeSpan.isPresent() && trace.isObservable()) {
@@ -772,7 +776,9 @@ public final class Tracer {
      * Returns the globally unique identifier for this thread's trace.
      */
     public static String getTraceId() {
-        return checkNotNull(currentTrace.get(), "There is no trace").getTraceId();
+        return checkNotNull(currentTrace.get(), "There is no trace")
+                .traceState()
+                .traceId();
     }
 
     /**
@@ -780,7 +786,11 @@ public final class Tracer {
      */
     static Optional<String> getForUserAgent() {
         Trace trace = currentTrace.get();
-        return trace == null ? Optional.empty() : trace.getForUserAgent();
+        if (trace == null) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(trace.traceState().forUserAgent());
     }
 
     /**
@@ -852,9 +862,9 @@ public final class Tracer {
         currentTrace.set(trace);
 
         // Give log appenders access to the trace id and whether the trace is being sampled
-        MDC.put(Tracers.TRACE_ID_KEY, trace.getTraceId());
+        MDC.put(Tracers.TRACE_ID_KEY, trace.traceState().traceId());
         setTraceSampledMdcIfObservable(trace.isObservable());
-        setTraceRequestId(trace.maybeGetRequestId());
+        setTraceRequestId(trace.traceState().requestId());
     }
 
     private static void setTraceSampledMdcIfObservable(boolean observable) {

--- a/tracing/src/test/java/com/palantir/tracing/TraceTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TraceTest.java
@@ -50,7 +50,7 @@ public final class TraceTest {
         Trace trace = Trace.of(true, TraceState.of("traceId", Optional.empty(), Optional.empty()));
 
         TraceLocal<String> traceLocal = TraceLocal.of();
-        trace.getTraceState().getOrCreateTraceLocals().put(traceLocal, "secret-value");
+        trace.traceState().getOrCreateTraceLocals().put(traceLocal, "secret-value");
 
         assertThat(trace.toString()).doesNotContain("secret");
     }

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -356,7 +356,7 @@ public final class TracerTest {
             assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(startTrace);
 
             Trace oldTrace = Tracer.getAndClearTrace();
-            assertThat(oldTrace.getTraceId()).isEqualTo(startTrace);
+            assertThat(oldTrace.traceState().traceId()).isEqualTo(startTrace);
             assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isNull(); // after clearing, it's empty
         } finally {
             Tracer.fastCompleteSpan();


### PR DESCRIPTION
`Trace` and `TraceState` are both internal, so there's no reason to duplicate the `TraceState` accessors in `Trace`.