### PR TITLE
Move isObservable into TraceState

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
@@ -60,8 +60,6 @@ public final class DeferredTracer implements Serializable {
     @Nullable
     private final TraceState traceState;
 
-    private final boolean isObservable;
-
     @Nullable
     private final String operation;
 
@@ -96,13 +94,11 @@ public final class DeferredTracer implements Serializable {
         if (maybeTrace.isPresent()) {
             Trace trace = maybeTrace.get();
             this.traceState = trace.traceState();
-            this.isObservable = trace.isObservable();
             this.parentSpanId = trace.top().map(OpenSpan::getSpanId).orElse(null);
             this.operation = operation;
             this.metadata = metadata;
         } else {
             this.traceState = null;
-            this.isObservable = false;
             this.parentSpanId = null;
             this.operation = null;
             this.metadata = null;
@@ -129,14 +125,14 @@ public final class DeferredTracer implements Serializable {
 
         Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
 
-        Tracer.setTrace(Trace.of(isObservable, traceState));
+        Tracer.setTrace(Trace.of(traceState));
         if (parentSpanId != null) {
             Tracer.fastStartSpan(operation, parentSpanId, SpanType.LOCAL);
         } else {
             Tracer.fastStartSpan(operation);
         }
 
-        if (isObservable && metadata != null && !metadata.isEmpty()) {
+        if (traceState.isObservable() && metadata != null && !metadata.isEmpty()) {
             return new TaggedCloseableTrace(originalTrace, metadata);
         } else {
             return originalTrace.map(CLOSEABLE_TRACE_FUNCTION).orElse(DefaultCloseableTrace.INSTANCE);

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -25,7 +25,6 @@ import com.google.errorprone.annotations.CheckReturnValue;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.tracing.api.OpenSpan;
-import com.palantir.tracing.api.SpanObserver;
 import com.palantir.tracing.api.SpanType;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -102,12 +101,6 @@ public abstract class Trace {
 
     abstract boolean isEmpty();
 
-    /**
-     * True iff the spans of this trace are to be observed by {@link SpanObserver span obververs} upon
-     * {@link Tracer#completeSpan span completion}.
-     */
-    abstract boolean isObservable();
-
     /** The state of the trace which is stored for each created trace. */
     final TraceState traceState() {
         return traceState;
@@ -116,13 +109,8 @@ public abstract class Trace {
     /** Returns a copy of this Trace which can be independently mutated. */
     abstract Trace deepCopy();
 
-    @Deprecated
-    static Trace of(boolean isObservable, String traceId, Optional<String> requestId) {
-        return of(isObservable, TraceState.of(traceId, requestId, Optional.empty()));
-    }
-
-    static Trace of(boolean isObservable, TraceState traceState) {
-        return isObservable ? new Sampled(traceState) : new Unsampled(traceState);
+    static Trace of(TraceState traceState) {
+        return traceState.isObservable() ? new Sampled(traceState) : new Unsampled(traceState);
     }
 
     private static final class Sampled extends Trace {
@@ -168,11 +156,6 @@ public abstract class Trace {
         @Override
         boolean isEmpty() {
             return stack.isEmpty();
-        }
-
-        @Override
-        boolean isObservable() {
-            return true;
         }
 
         @Override
@@ -236,11 +219,6 @@ public abstract class Trace {
         boolean isEmpty() {
             validateNumberOfSpans();
             return numberOfSpans <= 0;
-        }
-
-        @Override
-        boolean isObservable() {
-            return false;
         }
 
         @Override

--- a/tracing/src/main/java/com/palantir/tracing/TraceState.java
+++ b/tracing/src/main/java/com/palantir/tracing/TraceState.java
@@ -42,24 +42,28 @@ final class TraceState implements Serializable {
     @Nullable
     private final String forUserAgent;
 
+    private final boolean isObservable;
+
     @Nullable
     private volatile TraceLocalMap traceLocals;
 
     private static final AtomicReferenceFieldUpdater<TraceState, TraceLocalMap> traceLocalsUpdater =
             AtomicReferenceFieldUpdater.newUpdater(TraceState.class, TraceLocalMap.class, "traceLocals");
 
-    static TraceState of(String traceId, Optional<String> requestId, Optional<String> forUserAgent) {
+    static TraceState of(
+            String traceId, Optional<String> requestId, Optional<String> forUserAgent, boolean isObservable) {
         checkArgument(!Strings.isNullOrEmpty(traceId), "traceId must be non-empty");
         checkNotNull(requestId, "requestId should be not-null");
         checkNotNull(forUserAgent, "forUserAgent should be not-null");
-        return new TraceState(traceId, requestId.orElse(null), forUserAgent.orElse(null));
+        return new TraceState(traceId, requestId.orElse(null), forUserAgent.orElse(null), isObservable);
     }
 
-    private TraceState(String traceId, @Nullable String requestId, @Nullable String forUserAgent) {
+    private TraceState(
+            String traceId, @Nullable String requestId, @Nullable String forUserAgent, boolean isObservable) {
         this.traceId = traceId;
         this.requestId = requestId;
         this.forUserAgent = forUserAgent;
-        this.traceLocals = null;
+        this.isObservable = isObservable;
     }
 
     /**
@@ -89,6 +93,10 @@ final class TraceState implements Serializable {
         return forUserAgent;
     }
 
+    boolean isObservable() {
+        return isObservable;
+    }
+
     Map<TraceLocal<?>, Object> getOrCreateTraceLocals() {
         TraceLocalMap result = traceLocalsUpdater.get(this);
 
@@ -112,7 +120,8 @@ final class TraceState implements Serializable {
         return "TraceState{"
                 + "traceId='" + traceId + "', "
                 + "requestId='" + requestId + "', "
-                + "forUserAgent='" + forUserAgent
+                + "forUserAgent='" + forUserAgent + "', "
+                + "isObservable='" + isObservable
                 + "'}";
     }
 

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -82,8 +82,7 @@ public final class Tracer {
     private static Trace createTrace(
             Observability observability, String traceId, Optional<String> requestId, Optional<String> forUserAgent) {
         checkArgument(!Strings.isNullOrEmpty(traceId), "traceId must be non-empty");
-        boolean observable = shouldObserve(observability);
-        return Trace.of(observable, TraceState.of(traceId, requestId, forUserAgent));
+        return Trace.of(TraceState.of(traceId, requestId, forUserAgent, shouldObserve(observability)));
     }
 
     private static boolean shouldObserve(Observability observability) {
@@ -267,12 +266,24 @@ public final class Tracer {
      * utility that should not be called directly outside of {@link DetachedSpan}.
      */
     static DetachedSpan detachInternal(@Safe String operation, SpanType type) {
-        Trace maybeCurrentTrace = currentTrace.get();
-        TraceState traceState = getTraceState(maybeCurrentTrace, type);
-        boolean sampled = maybeCurrentTrace != null ? maybeCurrentTrace.isObservable() : sampler.sample();
-        Optional<String> parentSpan = getParentSpanId(maybeCurrentTrace);
-        return sampled
-                ? new SampledDetachedSpan(operation, type, traceState, parentSpan)
+        Trace trace = currentTrace.get();
+
+        TraceState traceState;
+        Optional<String> parentSpanId;
+        if (trace != null) {
+            traceState = trace.traceState();
+            parentSpanId = trace.top().map(OpenSpan::getSpanId);
+        } else {
+            traceState = TraceState.of(
+                    Tracers.randomId(),
+                    type == SpanType.SERVER_INCOMING ? Optional.of(Tracers.randomId()) : Optional.empty(),
+                    Optional.empty(),
+                    sampler.sample());
+            parentSpanId = Optional.empty();
+        }
+
+        return traceState.isObservable()
+                ? new SampledDetachedSpan(operation, type, traceState, parentSpanId)
                 : new UnsampledDetachedSpan(traceState, Optional.empty());
     }
 
@@ -306,8 +317,8 @@ public final class Tracer {
             SpanType type) {
         // The current trace has no impact on this function, a new trace is spawned and existing thread state
         // is not modified.
-        TraceState traceState = TraceState.of(traceId, requestId, forUserAgent);
-        return shouldObserve(observability)
+        TraceState traceState = TraceState.of(traceId, requestId, forUserAgent, shouldObserve(observability));
+        return traceState.isObservable()
                 ? new SampledDetachedSpan(operation, type, traceState, parentSpanId)
                 : new UnsampledDetachedSpan(traceState, parentSpanId);
     }
@@ -322,50 +333,25 @@ public final class Tracer {
             return NopDetached.INSTANCE;
         }
 
-        if (trace.isObservable()) {
-            OpenSpan maybeOpenSpan = trace.top().orElse(null);
-            if (maybeOpenSpan == null) {
+        if (trace.traceState().isObservable()) {
+            OpenSpan openSpan = trace.top().orElse(null);
+            if (openSpan == null) {
                 return NopDetached.INSTANCE;
             }
-            return new SampledDetached(trace.traceState(), maybeOpenSpan);
+            return new SampledDetached(trace.traceState(), openSpan);
         } else {
             return new UnsampledDetachedSpan(trace.traceState(), Optional.empty());
         }
     }
 
-    private static Optional<String> getParentSpanId(@Nullable Trace trace) {
-        if (trace != null) {
-            Optional<OpenSpan> maybeOpenSpan = trace.top();
-            if (maybeOpenSpan.isPresent()) {
-                return Optional.of(maybeOpenSpan.get().getSpanId());
-            }
-        }
-        return Optional.empty();
-    }
-
     @Nullable
     static TraceState getTraceState() {
-        Trace maybeCurrentTrace = currentTrace.get();
-
-        if (maybeCurrentTrace == null) {
+        Trace trace = currentTrace.get();
+        if (trace == null) {
             return null;
         }
 
-        return maybeCurrentTrace.traceState();
-    }
-
-    private static TraceState getTraceState(@Nullable Trace maybeCurrentTrace, SpanType newSpanType) {
-        if (maybeCurrentTrace != null) {
-            return maybeCurrentTrace.traceState();
-        }
-        return TraceState.of(Tracers.randomId(), getRequestIdForSpan(newSpanType), Optional.empty());
-    }
-
-    private static Optional<String> getRequestIdForSpan(SpanType newSpanType) {
-        if (newSpanType == SpanType.SERVER_INCOMING) {
-            return Optional.of(Tracers.randomId());
-        }
-        return Optional.empty();
+        return trace.traceState();
     }
 
     static Optional<String> getRequestId(DetachedSpan detachedSpan) {
@@ -429,10 +415,10 @@ public final class Tracer {
                 TagTranslator<? super T> translator,
                 T data,
                 SpanType type) {
-            Trace maybeCurrentTrace = currentTrace.get();
-            setTrace(Trace.of(true, traceState));
+            Trace trace = currentTrace.get();
+            setTrace(Trace.of(traceState));
             Tracer.fastStartSpan(operationName, openSpan.getSpanId(), type);
-            return TraceRestoringCloseableSpanWithMetadata.of(maybeCurrentTrace, translator, data);
+            return TraceRestoringCloseableSpanWithMetadata.of(trace, translator, data);
         }
 
         @Override
@@ -449,8 +435,8 @@ public final class Tracer {
 
         @MustBeClosed
         private static CloseableSpan attach(OpenSpan openSpan, TraceState traceState) {
-            Trace maybeCurrentTrace = currentTrace.get();
-            Trace newTrace = Trace.of(true, traceState);
+            Trace originalTrace = currentTrace.get();
+            Trace newTrace = Trace.of(traceState);
             // Push the DetachedSpan OpenSpan to provide the correct parent information
             // to child spans created within the context of this attach.
             // It is VITAL that this span is never completed, it exists only for attribution.
@@ -458,7 +444,7 @@ public final class Tracer {
             setTrace(newTrace);
             // Do not complete the synthetic root span, it simply prevents nested spans from removing trace state, and
             // allows
-            return maybeCurrentTrace == null ? REMOVE_TRACE : () -> Tracer.setTrace(maybeCurrentTrace);
+            return originalTrace == null ? REMOVE_TRACE : () -> Tracer.setTrace(originalTrace);
         }
 
         @Override
@@ -522,16 +508,14 @@ public final class Tracer {
         @Override
         public <T> CloseableSpan childSpan(
                 String operationName, TagTranslator<? super T> _translator, T _data, SpanType type) {
-            Trace maybeCurrentTrace = currentTrace.get();
-            setTrace(Trace.of(false, traceState));
+            Trace originalTrace = currentTrace.get();
+            setTrace(Trace.of(traceState));
             if (parentSpanId.isPresent()) {
                 Tracer.fastStartSpan(operationName, parentSpanId.get(), type);
             } else {
                 Tracer.fastStartSpan(operationName, type);
             }
-            return maybeCurrentTrace == null
-                    ? DEFAULT_CLOSEABLE_SPAN
-                    : new TraceRestoringCloseableSpan(maybeCurrentTrace);
+            return originalTrace == null ? DEFAULT_CLOSEABLE_SPAN : new TraceRestoringCloseableSpan(originalTrace);
         }
 
         @Override
@@ -594,22 +578,18 @@ public final class Tracer {
 
     public static <T> void fastCompleteSpan(TagTranslator<? super T> tag, T state) {
         Trace trace = currentTrace.get();
-        if (trace != null) {
-            Optional<OpenSpan> span = popCurrentSpan(trace);
-            if (trace.isObservable()) {
-                completeSpanAndNotifyObservers(
-                        span, tag, state, trace.traceState().traceId());
-            }
-        } else {
+        if (trace == null) {
             logCompletedWithoutStarted();
+            return;
         }
-    }
 
-    private static <T> void completeSpanAndNotifyObservers(
-            Optional<OpenSpan> openSpan, TagTranslator<? super T> tag, T state, String traceId) {
-        //noinspection OptionalIsPresent - Avoid lambda allocation in hot paths
-        if (openSpan.isPresent()) {
-            Tracer.notifyObservers(toSpan(openSpan.get(), tag, state, traceId));
+        OpenSpan span = popCurrentSpan(trace).orElse(null);
+        if (span == null) {
+            return;
+        }
+
+        if (trace.traceState().isObservable()) {
+            Tracer.notifyObservers(toSpan(span, tag, state, trace.traceState().traceId()));
         }
     }
 
@@ -636,20 +616,23 @@ public final class Tracer {
             logCompletedWithoutStarted();
             return Optional.empty();
         }
-        Optional<Span> maybeSpan = popCurrentSpan(trace)
-                .map(openSpan -> toSpan(
-                        openSpan,
-                        MapTagTranslator.INSTANCE,
-                        metadata,
-                        trace.traceState().traceId()));
 
-        // Notify subscribers iff trace is observable
-        if (maybeSpan.isPresent() && trace.isObservable()) {
-            // Avoid lambda allocation in hot paths
-            notifyObservers(maybeSpan.get());
+        OpenSpan openSpan = popCurrentSpan(trace).orElse(null);
+        if (openSpan == null) {
+            return Optional.empty();
         }
 
-        return maybeSpan;
+        Span span = toSpan(
+                openSpan,
+                MapTagTranslator.INSTANCE,
+                metadata,
+                trace.traceState().traceId());
+
+        if (trace.traceState().isObservable()) {
+            notifyObservers(span);
+        }
+
+        return Optional.of(span);
     }
 
     private static void logCompletedWithoutStarted() {
@@ -831,7 +814,11 @@ public final class Tracer {
      */
     public static boolean isTraceObservable() {
         Trace trace = currentTrace.get();
-        return trace != null && trace.isObservable();
+        if (trace == null) {
+            return false;
+        }
+
+        return trace.traceState().isObservable();
     }
 
     /**
@@ -841,7 +828,11 @@ public final class Tracer {
      */
     public static boolean hasUnobservableTrace() {
         Trace trace = currentTrace.get();
-        return trace != null && !trace.isObservable();
+        if (trace == null) {
+            return false;
+        }
+
+        return !trace.traceState().isObservable();
     }
 
     /**
@@ -863,7 +854,7 @@ public final class Tracer {
 
         // Give log appenders access to the trace id and whether the trace is being sampled
         MDC.put(Tracers.TRACE_ID_KEY, trace.traceState().traceId());
-        setTraceSampledMdcIfObservable(trace.isObservable());
+        setTraceSampledMdcIfObservable(trace.traceState().isObservable());
         setTraceRequestId(trace.traceState().requestId());
     }
 

--- a/tracing/src/test/java/com/palantir/tracing/TraceTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TraceTest.java
@@ -28,26 +28,30 @@ public final class TraceTest {
 
     @Test
     public void constructTrace_emptyTraceId() {
-        assertThatThrownBy(() -> Trace.of(false, TraceState.of("", Optional.empty(), Optional.empty())))
+        assertThatThrownBy(() -> Trace.of(TraceState.of("", Optional.empty(), Optional.empty(), false)))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void testToString() {
-        Trace trace = Trace.of(true, TraceState.of("traceId", Optional.empty(), Optional.empty()));
+        Trace trace = Trace.of(TraceState.of("traceId", Optional.empty(), Optional.empty(), true));
         OpenSpan span = trace.startSpan("operation", SpanType.LOCAL);
         assertThat(trace.toString())
                 .isEqualTo("Trace{"
                         + "stack=[" + span + "], "
                         + "isObservable=true, "
-                        + "state=TraceState{traceId='traceId', requestId='null', forUserAgent='null'}}")
+                        + "state=TraceState{"
+                        + "traceId='traceId', "
+                        + "requestId='null', "
+                        + "forUserAgent='null', "
+                        + "isObservable='true'}}")
                 .contains(span.getOperation())
                 .contains(span.getSpanId());
     }
 
     @Test
     public void testToString_doesNotContainTraceLocals() {
-        Trace trace = Trace.of(true, TraceState.of("traceId", Optional.empty(), Optional.empty()));
+        Trace trace = Trace.of(TraceState.of("traceId", Optional.empty(), Optional.empty(), true));
 
         TraceLocal<String> traceLocal = TraceLocal.of();
         trace.traceState().getOrCreateTraceLocals().put(traceLocal, "secret-value");

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -147,14 +147,14 @@ public final class TracerTest {
     public void testObserversAreInvokedOnObservableTracesOnly() throws Exception {
         Tracer.subscribe("1", observer1);
 
-        Tracer.setTrace(Trace.of(true, TraceState.of(Tracers.randomId(), Optional.empty(), Optional.empty())));
+        Tracer.setTrace(Trace.of(TraceState.of(Tracers.randomId(), Optional.empty(), Optional.empty(), true)));
         Span span = startAndCompleteSpan();
         verify(observer1).consume(span);
         span = startAndCompleteSpan();
         verify(observer1).consume(span);
         verifyNoMoreInteractions(observer1);
 
-        Tracer.setTrace(Trace.of(false, TraceState.of(Tracers.randomId(), Optional.empty(), Optional.empty())));
+        Tracer.setTrace(Trace.of(TraceState.of(Tracers.randomId(), Optional.empty(), Optional.empty(), false)));
         startAndFastCompleteSpan(); // not sampled, see above
         verifyNoMoreInteractions(observer1);
     }
@@ -165,7 +165,7 @@ public final class TracerTest {
         assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isNull();
         assertThat(Tracer.hasTraceId()).isFalse();
         assertThat(Tracer.hasUnobservableTrace()).isFalse();
-        Tracer.setTrace(Trace.of(false, TraceState.of(traceId, Optional.empty(), Optional.empty())));
+        Tracer.setTrace(Trace.of(TraceState.of(traceId, Optional.empty(), Optional.empty(), false)));
         // Unsampled trace should still apply thread state
         assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(traceId);
         assertThat(Tracer.hasTraceId()).isTrue();
@@ -219,7 +219,7 @@ public final class TracerTest {
     @Test
     public void testSetTraceSetsCurrentTraceAndMdcTraceIdKey() throws Exception {
         Tracer.fastStartSpan("operation");
-        Tracer.setTrace(Trace.of(true, TraceState.of("newTraceId", Optional.empty(), Optional.empty())));
+        Tracer.setTrace(Trace.of(TraceState.of("newTraceId", Optional.empty(), Optional.empty(), true)));
         assertThat(Tracer.getTraceId()).isEqualTo("newTraceId");
         assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo("newTraceId");
         assertThat(Tracer.completeSpan()).isEmpty();
@@ -228,7 +228,7 @@ public final class TracerTest {
 
     @Test
     public void testSetTraceSetsMdcTraceSampledKeyWhenObserved() {
-        Tracer.setTrace(Trace.of(true, TraceState.of("observedTraceId", Optional.empty(), Optional.empty())));
+        Tracer.setTrace(Trace.of(TraceState.of("observedTraceId", Optional.empty(), Optional.empty(), true)));
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isEqualTo("1");
         assertThat(Tracer.completeSpan()).isEmpty();
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isNull();
@@ -236,7 +236,7 @@ public final class TracerTest {
 
     @Test
     public void testSetTraceMissingMdcTraceSampledKeyWhenNotObserved() {
-        Tracer.setTrace(Trace.of(false, TraceState.of("notObservedTraceId", Optional.empty(), Optional.empty())));
+        Tracer.setTrace(Trace.of(TraceState.of("notObservedTraceId", Optional.empty(), Optional.empty(), false)));
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isNull();
         assertThat(Tracer.completeSpan()).isEmpty();
         assertThat(MDC.get(Tracers.TRACE_SAMPLED_KEY)).isNull();
@@ -337,7 +337,7 @@ public final class TracerTest {
 
     @Test
     public void testGetAndClearTraceIfPresent() {
-        Trace trace = Trace.of(true, TraceState.of("newTraceId", Optional.empty(), Optional.empty()));
+        Trace trace = Trace.of(TraceState.of("newTraceId", Optional.empty(), Optional.empty(), true));
         Tracer.setTrace(trace);
 
         Optional<Trace> nonEmptyTrace = Tracer.getAndClearTraceIfPresent();

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -537,7 +537,7 @@ public final class TracersTest {
     @Test
     public void testWrapCallableWithNewTrace_canSpecifyObservability() throws Exception {
         Callable<Boolean> rawCallable = () -> {
-            return Tracer.copyTrace().get().isObservable();
+            return Tracer.copyTrace().get().traceState().isObservable();
         };
 
         Callable<Boolean> sampledCallable = Tracers.wrapWithNewTrace("someTraceId", Observability.SAMPLE, rawCallable);
@@ -610,15 +610,15 @@ public final class TracersTest {
 
     @Test
     public void testWrapCallableWithAlternateTraceId_canSpecifyObservability() throws Exception {
-        Callable<?> sampledCallable =
-                () -> assertThat(Tracer.copyTrace().get().isObservable()).isTrue();
+        Callable<?> sampledCallable = () ->
+                assertThat(Tracer.copyTrace().get().traceState().isObservable()).isTrue();
         Callable<?> wrappedSampledCallable =
                 Tracers.wrapWithAlternateTraceId("someTraceId", "operation", Observability.SAMPLE, sampledCallable);
 
         wrappedSampledCallable.call();
 
-        Callable<?> unSampledCallable =
-                () -> assertThat(Tracer.copyTrace().get().isObservable()).isFalse();
+        Callable<?> unSampledCallable = () ->
+                assertThat(Tracer.copyTrace().get().traceState().isObservable()).isFalse();
         Callable<?> wrappedUnSampledCallable = Tracers.wrapWithAlternateTraceId(
                 "someTraceId", "operation", Observability.DO_NOT_SAMPLE, unSampledCallable);
 
@@ -717,7 +717,7 @@ public final class TracersTest {
     @Test
     public void testWrapRunnableWithNewTrace_canSpecifyObservability() {
         Runnable rawSampledRunnable = () -> {
-            assertThat(Tracer.copyTrace().get().isObservable()).isTrue();
+            assertThat(Tracer.copyTrace().get().traceState().isObservable()).isTrue();
         };
 
         Runnable sampledRunnable = Tracers.wrapWithNewTrace("someTraceId", Observability.SAMPLE, rawSampledRunnable);
@@ -725,7 +725,7 @@ public final class TracersTest {
         sampledRunnable.run();
 
         Runnable rawUnSampledRunnable = () -> {
-            assertThat(Tracer.copyTrace().get().isObservable()).isFalse();
+            assertThat(Tracer.copyTrace().get().traceState().isObservable()).isFalse();
         };
 
         Runnable unSampledRunnable =
@@ -818,15 +818,15 @@ public final class TracersTest {
 
     @Test
     public void testWrapRunnableWithAlternateTraceId_canSpecifyObservability() {
-        Runnable sampledRunnable =
-                () -> assertThat(Tracer.copyTrace().get().isObservable()).isTrue();
+        Runnable sampledRunnable = () ->
+                assertThat(Tracer.copyTrace().get().traceState().isObservable()).isTrue();
         Runnable wrappedSampledRunnable =
                 Tracers.wrapWithAlternateTraceId("someTraceId", "operation", Observability.SAMPLE, sampledRunnable);
 
         wrappedSampledRunnable.run();
 
-        Runnable unSampledRunnable =
-                () -> assertThat(Tracer.copyTrace().get().isObservable()).isFalse();
+        Runnable unSampledRunnable = () ->
+                assertThat(Tracer.copyTrace().get().traceState().isObservable()).isFalse();
         Runnable wrappedUnSampledRunnable = Tracers.wrapWithAlternateTraceId(
                 "someTraceId", "operation", Observability.DO_NOT_SAMPLE, unSampledRunnable);
 


### PR DESCRIPTION
A trace's observability is a fixed property of the trace that we want to be consistent. We don't (and shouldn't) allow a trace to be used in different places with different observability.

This probably should have been done when we introduced `TraceState` in https://github.com/palantir/tracing-java/pull/787.

