### PR TITLE
Remove Trace.deepCopy

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
@@ -90,9 +90,8 @@ public final class DeferredTracer implements Serializable {
     }
 
     public DeferredTracer(@Safe String operation, @Safe Map<String, String> metadata) {
-        Optional<Trace> maybeTrace = Tracer.copyTrace();
-        if (maybeTrace.isPresent()) {
-            Trace trace = maybeTrace.get();
+        Trace trace = Tracer.getTrace();
+        if (trace != null) {
             this.traceState = trace.traceState();
             this.parentSpanId = trace.top().map(OpenSpan::getSpanId).orElse(null);
             this.operation = operation;

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -106,9 +106,6 @@ public abstract class Trace {
         return traceState;
     }
 
-    /** Returns a copy of this Trace which can be independently mutated. */
-    abstract Trace deepCopy();
-
     static Trace of(TraceState traceState) {
         return traceState.isObservable() ? new Sampled(traceState) : new Unsampled(traceState);
     }
@@ -156,11 +153,6 @@ public abstract class Trace {
         @Override
         boolean isEmpty() {
             return stack.isEmpty();
-        }
-
-        @Override
-        Trace deepCopy() {
-            return new Sampled(new ArrayDeque<>(stack), traceState());
         }
 
         @Override
@@ -219,11 +211,6 @@ public abstract class Trace {
         boolean isEmpty() {
             validateNumberOfSpans();
             return numberOfSpans <= 0;
-        }
-
-        @Override
-        Trace deepCopy() {
-            return new Unsampled(numberOfSpans, traceState());
         }
 
         /** Internal validation, this should never fail because {@link #pop()} only decrements positive values. */

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -835,15 +835,9 @@ public final class Tracer {
         return !trace.traceState().isObservable();
     }
 
-    /**
-     * Returns an independent copy of this thread's {@link Trace}.
-     */
-    static Optional<Trace> copyTrace() {
-        Trace trace = currentTrace.get();
-        if (trace != null) {
-            return Optional.of(trace.deepCopy());
-        }
-        return Optional.empty();
+    @Nullable
+    static Trace getTrace() {
+        return currentTrace.get();
     }
 
     /**

--- a/tracing/src/test/java/com/palantir/tracing/CloseableTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/CloseableTracerTest.java
@@ -42,7 +42,7 @@ public final class CloseableTracerTest {
     @Test
     public void startsAndClosesSpan() {
         try (CloseableTracer tracer = CloseableTracer.startSpan("foo")) {
-            OpenSpan openSpan = Tracer.copyTrace().get().top().get();
+            OpenSpan openSpan = Tracer.getTrace().top().get();
             assertThat(openSpan.getOperation()).isEqualTo("foo");
             assertThat(openSpan.type()).isEqualTo(SpanType.LOCAL);
         }
@@ -52,7 +52,7 @@ public final class CloseableTracerTest {
     @Test
     public void startsAndClosesSpanWithType() {
         try (CloseableTracer tracer = CloseableTracer.startSpan("foo", SpanType.CLIENT_OUTGOING)) {
-            OpenSpan openSpan = Tracer.copyTrace().get().top().get();
+            OpenSpan openSpan = Tracer.getTrace().top().get();
             assertThat(openSpan.getOperation()).isEqualTo("foo");
             assertThat(openSpan.type()).isEqualTo(SpanType.CLIENT_OUTGOING);
         }
@@ -66,7 +66,7 @@ public final class CloseableTracerTest {
         Tracer.subscribe(name, observer);
         try {
             try (CloseableTracer tracer = CloseableTracer.startSpan("foo", ImmutableMap.of("key", "value"))) {
-                OpenSpan openSpan = Tracer.copyTrace().get().top().get();
+                OpenSpan openSpan = Tracer.getTrace().top().get();
                 assertThat(openSpan.getOperation()).isEqualTo("foo");
                 assertThat(openSpan.type()).isEqualTo(SpanType.LOCAL);
             }
@@ -96,7 +96,7 @@ public final class CloseableTracerTest {
                         }
                     },
                     "value")) {
-                OpenSpan openSpan = Tracer.copyTrace().get().top().get();
+                OpenSpan openSpan = Tracer.getTrace().top().get();
                 assertThat(openSpan.getOperation()).isEqualTo("foo");
                 assertThat(openSpan.type()).isEqualTo(SpanType.LOCAL);
             }

--- a/tracing/src/test/java/com/palantir/tracing/TracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracerTest.java
@@ -205,18 +205,6 @@ public final class TracerTest {
     }
 
     @Test
-    public void testTraceCopyIsIndependent() throws Exception {
-        Tracer.fastStartSpan("span");
-        try {
-            Trace trace = Tracer.copyTrace().get();
-            trace.fastStartSpan("fop", SpanType.LOCAL);
-        } finally {
-            Tracer.fastCompleteSpan();
-        }
-        assertThat(Tracer.completeSpan()).isNotPresent();
-    }
-
-    @Test
     public void testSetTraceSetsCurrentTraceAndMdcTraceIdKey() throws Exception {
         Tracer.fastStartSpan("operation");
         Tracer.setTrace(Trace.of(TraceState.of("newTraceId", Optional.empty(), Optional.empty(), true)));

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -30,7 +30,6 @@ import com.palantir.tracing.api.OpenSpan;
 import com.palantir.tracing.api.Span;
 import com.palantir.tracing.api.SpanType;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -49,6 +48,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -537,7 +537,7 @@ public final class TracersTest {
     @Test
     public void testWrapCallableWithNewTrace_canSpecifyObservability() throws Exception {
         Callable<Boolean> rawCallable = () -> {
-            return Tracer.copyTrace().get().traceState().isObservable();
+            return Tracer.getTrace().traceState().isObservable();
         };
 
         Callable<Boolean> sampledCallable = Tracers.wrapWithNewTrace("someTraceId", Observability.SAMPLE, rawCallable);
@@ -610,15 +610,15 @@ public final class TracersTest {
 
     @Test
     public void testWrapCallableWithAlternateTraceId_canSpecifyObservability() throws Exception {
-        Callable<?> sampledCallable = () ->
-                assertThat(Tracer.copyTrace().get().traceState().isObservable()).isTrue();
+        Callable<?> sampledCallable =
+                () -> assertThat(Tracer.getTrace().traceState().isObservable()).isTrue();
         Callable<?> wrappedSampledCallable =
                 Tracers.wrapWithAlternateTraceId("someTraceId", "operation", Observability.SAMPLE, sampledCallable);
 
         wrappedSampledCallable.call();
 
-        Callable<?> unSampledCallable = () ->
-                assertThat(Tracer.copyTrace().get().traceState().isObservable()).isFalse();
+        Callable<?> unSampledCallable =
+                () -> assertThat(Tracer.getTrace().traceState().isObservable()).isFalse();
         Callable<?> wrappedUnSampledCallable = Tracers.wrapWithAlternateTraceId(
                 "someTraceId", "operation", Observability.DO_NOT_SAMPLE, unSampledCallable);
 
@@ -717,7 +717,7 @@ public final class TracersTest {
     @Test
     public void testWrapRunnableWithNewTrace_canSpecifyObservability() {
         Runnable rawSampledRunnable = () -> {
-            assertThat(Tracer.copyTrace().get().traceState().isObservable()).isTrue();
+            assertThat(Tracer.getTrace().traceState().isObservable()).isTrue();
         };
 
         Runnable sampledRunnable = Tracers.wrapWithNewTrace("someTraceId", Observability.SAMPLE, rawSampledRunnable);
@@ -725,7 +725,7 @@ public final class TracersTest {
         sampledRunnable.run();
 
         Runnable rawUnSampledRunnable = () -> {
-            assertThat(Tracer.copyTrace().get().traceState().isObservable()).isFalse();
+            assertThat(Tracer.getTrace().traceState().isObservable()).isFalse();
         };
 
         Runnable unSampledRunnable =
@@ -818,15 +818,15 @@ public final class TracersTest {
 
     @Test
     public void testWrapRunnableWithAlternateTraceId_canSpecifyObservability() {
-        Runnable sampledRunnable = () ->
-                assertThat(Tracer.copyTrace().get().traceState().isObservable()).isTrue();
+        Runnable sampledRunnable =
+                () -> assertThat(Tracer.getTrace().traceState().isObservable()).isTrue();
         Runnable wrappedSampledRunnable =
                 Tracers.wrapWithAlternateTraceId("someTraceId", "operation", Observability.SAMPLE, sampledRunnable);
 
         wrappedSampledRunnable.run();
 
-        Runnable unSampledRunnable = () ->
-                assertThat(Tracer.copyTrace().get().traceState().isObservable()).isFalse();
+        Runnable unSampledRunnable =
+                () -> assertThat(Tracer.getTrace().traceState().isObservable()).isFalse();
         Runnable wrappedUnSampledRunnable = Tracers.wrapWithAlternateTraceId(
                 "someTraceId", "operation", Observability.DO_NOT_SAMPLE, unSampledRunnable);
 
@@ -981,9 +981,9 @@ public final class TracersTest {
         return () -> {
             String traceId = Tracer.getTraceId();
             List<OpenSpan> trace = getCurrentTrace();
-            OpenSpan span = trace.remove(trace.size() - 1);
-            assertThat(trace).isEmpty();
+            assertThat(trace).hasSize(1);
 
+            OpenSpan span = trace.get(0);
             assertThat(traceId).isEqualTo(outsideTraceId);
             assertThat(span.getOperation()).isEqualTo(operation);
             assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(outsideTraceId);
@@ -1002,9 +1002,9 @@ public final class TracersTest {
         return () -> {
             String traceId = Tracer.getTraceId();
             List<OpenSpan> trace = getCurrentTrace();
-            OpenSpan span = trace.remove(trace.size() - 1);
-            assertThat(trace).isEmpty();
+            assertThat(trace).hasSize(1);
 
+            OpenSpan span = trace.get(0);
             assertThat(traceId).isEqualTo(outsideTraceId);
             assertThat(span.getOperation()).isEqualTo(operation);
             assertThat(MDC.get(Tracers.TRACE_ID_KEY)).isEqualTo(outsideTraceId);
@@ -1013,15 +1013,16 @@ public final class TracersTest {
     }
 
     private static List<OpenSpan> getCurrentTrace() {
-        return Tracer.copyTrace()
-                .map(trace -> {
-                    List<OpenSpan> spans = new ArrayList<>();
-                    while (!trace.isEmpty()) {
-                        spans.add(trace.pop().get());
-                    }
-                    return Lists.reverse(spans);
-                })
-                .orElseGet(Collections::emptyList);
+        Trace trace = Tracer.getTrace();
+        if (trace == null) {
+            return List.of();
+        }
+
+        List<OpenSpan> spans = Stream.generate(trace::pop)
+                .takeWhile(Optional::isPresent)
+                .map(Optional::orElseThrow)
+                .toList();
+        return Lists.reverse(spans);
     }
 
     private static <T extends ExecutorService> void withExecutor(Supplier<T> factory, ThrowingConsumer<T> test) {


### PR DESCRIPTION
This method is not necessary. Currently it is only used by the `DeferredTracer` constructor, which doesn't need a full copy.