### PR TITLE
Avoid some allocations

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java
@@ -92,8 +92,9 @@ public final class DeferredTracer implements Serializable {
     public DeferredTracer(@Safe String operation, @Safe Map<String, String> metadata) {
         Trace trace = Tracer.getTrace();
         if (trace != null) {
+            OpenSpan span = trace.top();
             this.traceState = trace.traceState();
-            this.parentSpanId = trace.top().map(OpenSpan::getSpanId).orElse(null);
+            this.parentSpanId = span != null ? span.getSpanId() : null;
             this.operation = operation;
             this.metadata = metadata;
         } else {

--- a/tracing/src/main/java/com/palantir/tracing/Trace.java
+++ b/tracing/src/main/java/com/palantir/tracing/Trace.java
@@ -29,6 +29,7 @@ import com.palantir.tracing.api.SpanType;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a trace as an ordered list of non-completed spans. Supports adding and removing of spans. This class is
@@ -59,9 +60,8 @@ public abstract class Trace {
     final OpenSpan startSpan(String operation, String parentSpanId, SpanType type) {
         checkState(isEmpty(), "Cannot start a span with explicit parent if the current thread's trace is non-empty");
         checkArgument(!Strings.isNullOrEmpty(parentSpanId), "parentSpanId must be non-empty");
-        OpenSpan span = OpenSpan.of(operation, Tracers.randomId(), type, Optional.of(parentSpanId));
-        push(span);
-        return span;
+
+        return startSpan(operation, Optional.of(parentSpanId), type);
     }
 
     /**
@@ -70,19 +70,13 @@ public abstract class Trace {
      */
     @CheckReturnValue
     final OpenSpan startSpan(String operation, SpanType type) {
-        Optional<OpenSpan> prevState = top();
-        final OpenSpan span;
-        //noinspection OptionalIsPresent - Avoid lambda allocation in hot paths
-        if (prevState.isPresent()) {
-            span = OpenSpan.of(
-                    operation,
-                    Tracers.randomId(),
-                    type,
-                    Optional.of(prevState.get().getSpanId()));
-        } else {
-            span = OpenSpan.of(operation, Tracers.randomId(), type, Optional.empty());
-        }
+        OpenSpan span = top();
 
+        return startSpan(operation, span != null ? Optional.of(span.getSpanId()) : Optional.empty(), type);
+    }
+
+    private OpenSpan startSpan(String operation, Optional<String> parentSpanId, SpanType type) {
+        OpenSpan span = OpenSpan.of(operation, Tracers.randomId(), type, parentSpanId);
         push(span);
         return span;
     }
@@ -93,11 +87,13 @@ public abstract class Trace {
     /** Like {@link #startSpan(String, SpanType)}, but does not return an {@link OpenSpan}. */
     abstract void fastStartSpan(String operation, SpanType type);
 
-    protected abstract void push(OpenSpan span);
+    abstract void push(OpenSpan span);
 
-    abstract Optional<OpenSpan> top();
+    @Nullable
+    abstract OpenSpan top();
 
-    abstract Optional<OpenSpan> pop();
+    @Nullable
+    abstract OpenSpan pop();
 
     abstract boolean isEmpty();
 
@@ -141,13 +137,15 @@ public abstract class Trace {
         }
 
         @Override
-        Optional<OpenSpan> top() {
-            return stack.isEmpty() ? Optional.empty() : Optional.of(stack.peekFirst());
+        @Nullable
+        OpenSpan top() {
+            return stack.peekFirst();
         }
 
         @Override
-        Optional<OpenSpan> pop() {
-            return stack.isEmpty() ? Optional.empty() : Optional.of(stack.pop());
+        @Nullable
+        OpenSpan pop() {
+            return stack.pollFirst();
         }
 
         @Override
@@ -194,17 +192,19 @@ public abstract class Trace {
         }
 
         @Override
-        Optional<OpenSpan> top() {
-            return Optional.empty();
+        @Nullable
+        OpenSpan top() {
+            return null;
         }
 
         @Override
-        Optional<OpenSpan> pop() {
+        @Nullable
+        OpenSpan pop() {
             validateNumberOfSpans();
             if (numberOfSpans > 0) {
                 numberOfSpans--;
             }
-            return Optional.empty();
+            return null;
         }
 
         @Override

--- a/tracing/src/main/java/com/palantir/tracing/Tracer.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracer.java
@@ -113,7 +113,7 @@ public final class Tracer {
             return Optional.empty();
         }
 
-        OpenSpan span = trace.top().orElse(null);
+        OpenSpan span = trace.top();
 
         return Optional.of(TraceMetadata.builder()
                 .traceId(trace.traceState().traceId())
@@ -271,8 +271,10 @@ public final class Tracer {
         TraceState traceState;
         Optional<String> parentSpanId;
         if (trace != null) {
+            OpenSpan span = trace.top();
+
             traceState = trace.traceState();
-            parentSpanId = trace.top().map(OpenSpan::getSpanId);
+            parentSpanId = span != null ? Optional.of(span.getSpanId()) : Optional.empty();
         } else {
             traceState = TraceState.of(
                     Tracers.randomId(),
@@ -300,21 +302,6 @@ public final class Tracer {
             SpanType type) {
         Optional<String> requestId =
                 type == SpanType.SERVER_INCOMING ? Optional.of(Tracers.randomId()) : Optional.empty();
-        return detachInternal(observability, traceId, requestId, forUserAgent, parentSpanId, operation, type);
-    }
-
-    /**
-     * Like {@link #startSpan(String, SpanType)}, but does not set or modify tracing thread state. This is an internal
-     * utility that should not be called directly outside of {@link DetachedSpan}.
-     */
-    static DetachedSpan detachInternal(
-            Observability observability,
-            String traceId,
-            Optional<String> requestId,
-            Optional<String> forUserAgent,
-            Optional<String> parentSpanId,
-            @Safe String operation,
-            SpanType type) {
         // The current trace has no impact on this function, a new trace is spawned and existing thread state
         // is not modified.
         TraceState traceState = TraceState.of(traceId, requestId, forUserAgent, shouldObserve(observability));
@@ -334,7 +321,7 @@ public final class Tracer {
         }
 
         if (trace.traceState().isObservable()) {
-            OpenSpan openSpan = trace.top().orElse(null);
+            OpenSpan openSpan = trace.top();
             if (openSpan == null) {
                 return NopDetached.INSTANCE;
             }
@@ -583,7 +570,7 @@ public final class Tracer {
             return;
         }
 
-        OpenSpan span = popCurrentSpan(trace).orElse(null);
+        OpenSpan span = popCurrentSpan(trace);
         if (span == null) {
             return;
         }
@@ -617,7 +604,7 @@ public final class Tracer {
             return Optional.empty();
         }
 
-        OpenSpan openSpan = popCurrentSpan(trace).orElse(null);
+        OpenSpan openSpan = popCurrentSpan(trace);
         if (openSpan == null) {
             return Optional.empty();
         }
@@ -648,8 +635,9 @@ public final class Tracer {
         compositeObserver.accept(span);
     }
 
-    private static Optional<OpenSpan> popCurrentSpan(Trace trace) {
-        Optional<OpenSpan> span = trace.pop();
+    @Nullable
+    private static OpenSpan popCurrentSpan(Trace trace) {
+        OpenSpan span = trace.pop();
         if (trace.isEmpty()) {
             clearCurrentTrace();
         }

--- a/tracing/src/test/java/com/palantir/tracing/CloseableTracerTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/CloseableTracerTest.java
@@ -42,21 +42,21 @@ public final class CloseableTracerTest {
     @Test
     public void startsAndClosesSpan() {
         try (CloseableTracer tracer = CloseableTracer.startSpan("foo")) {
-            OpenSpan openSpan = Tracer.getTrace().top().get();
+            OpenSpan openSpan = Tracer.getTrace().top();
             assertThat(openSpan.getOperation()).isEqualTo("foo");
             assertThat(openSpan.type()).isEqualTo(SpanType.LOCAL);
         }
-        assertThat(Tracer.getAndClearTrace().top()).isEmpty();
+        assertThat(Tracer.getAndClearTrace().top()).isNull();
     }
 
     @Test
     public void startsAndClosesSpanWithType() {
         try (CloseableTracer tracer = CloseableTracer.startSpan("foo", SpanType.CLIENT_OUTGOING)) {
-            OpenSpan openSpan = Tracer.getTrace().top().get();
+            OpenSpan openSpan = Tracer.getTrace().top();
             assertThat(openSpan.getOperation()).isEqualTo("foo");
             assertThat(openSpan.type()).isEqualTo(SpanType.CLIENT_OUTGOING);
         }
-        assertThat(Tracer.getAndClearTrace().top()).isEmpty();
+        assertThat(Tracer.getAndClearTrace().top()).isNull();
     }
 
     @Test
@@ -66,11 +66,11 @@ public final class CloseableTracerTest {
         Tracer.subscribe(name, observer);
         try {
             try (CloseableTracer tracer = CloseableTracer.startSpan("foo", ImmutableMap.of("key", "value"))) {
-                OpenSpan openSpan = Tracer.getTrace().top().get();
+                OpenSpan openSpan = Tracer.getTrace().top();
                 assertThat(openSpan.getOperation()).isEqualTo("foo");
                 assertThat(openSpan.type()).isEqualTo(SpanType.LOCAL);
             }
-            assertThat(Tracer.getAndClearTrace().top()).isEmpty();
+            assertThat(Tracer.getAndClearTrace().top()).isNull();
             ArgumentCaptor<Span> captor = ArgumentCaptor.forClass(Span.class);
             Mockito.verify(observer).consume(captor.capture());
             Span emitted = captor.getValue();
@@ -96,11 +96,11 @@ public final class CloseableTracerTest {
                         }
                     },
                     "value")) {
-                OpenSpan openSpan = Tracer.getTrace().top().get();
+                OpenSpan openSpan = Tracer.getTrace().top();
                 assertThat(openSpan.getOperation()).isEqualTo("foo");
                 assertThat(openSpan.type()).isEqualTo(SpanType.LOCAL);
             }
-            assertThat(Tracer.getAndClearTrace().top()).isEmpty();
+            assertThat(Tracer.getAndClearTrace().top()).isNull();
             ArgumentCaptor<Span> captor = ArgumentCaptor.forClass(Span.class);
             Mockito.verify(observer).consume(captor.capture());
             Span emitted = captor.getValue();

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -1018,10 +1019,8 @@ public final class TracersTest {
             return List.of();
         }
 
-        List<OpenSpan> spans = Stream.generate(trace::pop)
-                .takeWhile(Optional::isPresent)
-                .map(Optional::orElseThrow)
-                .toList();
+        List<OpenSpan> spans =
+                Stream.generate(trace::pop).takeWhile(Objects::nonNull).toList();
         return Lists.reverse(spans);
     }
 


### PR DESCRIPTION
Avoid some `Optional` and lambda allocations in `Trace.top` and `Trace.pop`.

Justifications:
- The majority of callers immediately call `.orElse(null)`.
- This is also consistent with the `TraceState` accessors, which also return nullable values. 