### PR TITLE
New Tracers.wrapSupplierWithAlternateTraceId() method

### DIFF
--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -450,8 +450,8 @@ public final class Tracers {
      * instead of any trace already set on the thread used to execute the callable. Each execution of the callable will
      * use a new {@link Trace tracing state} with the same given traceId. The given {@link String operation} is used to
      * create the initial span.
-     *
-     * @see {@link #wrapSupplierWithAlternateTraceId(String, String, Observability, Supplier)}
+     * <p>
+     * See also {@link #wrapSupplierWithAlternateTraceId(String, String, Observability, Supplier)}.
      */
     public static <V> Callable<V> wrapWithAlternateTraceId(
             String traceId, String operation, Observability observability, Callable<V> delegate) {

--- a/tracing/src/main/java/com/palantir/tracing/Tracers.java
+++ b/tracing/src/main/java/com/palantir/tracing/Tracers.java
@@ -450,6 +450,8 @@ public final class Tracers {
      * instead of any trace already set on the thread used to execute the callable. Each execution of the callable will
      * use a new {@link Trace tracing state} with the same given traceId. The given {@link String operation} is used to
      * create the initial span.
+     *
+     * @see {@link #wrapSupplierWithAlternateTraceId(String, String, Observability, Supplier)}
      */
     public static <V> Callable<V> wrapWithAlternateTraceId(
             String traceId, String operation, Observability observability, Callable<V> delegate) {
@@ -497,6 +499,33 @@ public final class Tracers {
             try {
                 Tracer.initTraceWithSpan(observability, traceId, operation, SpanType.LOCAL);
                 delegate.run();
+            } finally {
+                Tracer.fastCompleteSpan();
+                restoreTrace(originalTrace);
+            }
+        };
+    }
+
+    /**
+     * Wraps the given {@link Supplier} such that it creates a fresh {@link Trace tracing state with the given traceId}
+     * for its execution. That is, the trace during its {@link Supplier#get() execution} will use the traceId provided
+     * instead of any trace already set on the thread used to execute the callable. Each execution of the callable will
+     * use a new {@link Trace tracing state} with the same given traceId. The given {@link String operation} is used to
+     * create the initial span.
+     * <p>
+     * Compared to {@link #wrapWithAlternateTraceId(String, String, Observability, Callable)} which takes a {@link
+     * Callable}, using a {@link Supplier} can be easier for clients to work with since it does not have a checked
+     * exception in its signature.
+     */
+    public static <V> Supplier<V> wrapSupplierWithAlternateTraceId(
+            String traceId, String operation, Observability observability, Supplier<V> delegate) {
+        return () -> {
+            // clear the existing trace and keep it around for restoration when we're done
+            Optional<Trace> originalTrace = Tracer.getAndClearTraceIfPresent();
+
+            try {
+                Tracer.initTraceWithSpan(observability, traceId, operation, SpanType.LOCAL);
+                return delegate.get();
             } finally {
                 Tracer.fastCompleteSpan();
                 restoreTrace(originalTrace);

--- a/tracing/src/test/java/com/palantir/tracing/TracersTest.java
+++ b/tracing/src/test/java/com/palantir/tracing/TracersTest.java
@@ -834,6 +834,99 @@ public final class TracersTest {
         wrappedUnSampledRunnable.run();
     }
 
+    @SuppressWarnings("ReturnValueIgnored")
+    @Test
+    public void testWrapSupplierWithAlternateTraceId_traceStateInsideSupplierUsesGivenTraceId() {
+        String traceIdBeforeConstruction = Tracer.getTraceId();
+        AtomicReference<String> traceId = new AtomicReference<>();
+        String traceIdToUse = "someTraceId";
+        Supplier<String> wrappedSupplier =
+                Tracers.wrapSupplierWithAlternateTraceId(traceIdToUse, "operation", Observability.UNDECIDED, () -> {
+                    traceId.set(Tracer.getTraceId());
+                    return "hi";
+                });
+
+        wrappedSupplier.get();
+
+        String traceIdAfterCall = Tracer.getTraceId();
+
+        assertThat(traceId.get())
+                .isNotEqualTo(traceIdBeforeConstruction)
+                .isNotEqualTo(traceIdAfterCall)
+                .isEqualTo(traceIdToUse);
+
+        assertThat(traceIdBeforeConstruction).isEqualTo(traceIdAfterCall);
+    }
+
+    @SuppressWarnings("ReturnValueIgnored")
+    @Test
+    public void testWrapSupplierWithAlternateTraceId_traceStateInsideSupplierHasGivenSpan() {
+        List<List<OpenSpan>> spans = new ArrayList<>();
+
+        String traceIdToUse = "someTraceId";
+        Supplier<String> wrappedSupplier =
+                Tracers.wrapSupplierWithAlternateTraceId(traceIdToUse, "operation", Observability.UNDECIDED, () -> {
+                    spans.add(getCurrentTrace());
+                    return "hi";
+                });
+
+        wrappedSupplier.get();
+
+        assertThat(spans.get(0)).hasSize(1);
+
+        OpenSpan span = spans.get(0).get(0);
+
+        assertThat(span.getOperation()).isEqualTo("operation");
+        assertThat(span.getParentSpanId()).isEmpty();
+    }
+
+    @Test
+    public void testWrapSupplierWithAlternateTraceId_traceStateRestoredWhenThrows() {
+        String traceIdBeforeConstruction = Tracer.getTraceId();
+        Supplier<String> rawSupplier = () -> {
+            throw new IllegalStateException("oopsies");
+        };
+        Supplier<String> wrappedSupplier = Tracers.wrapSupplierWithAlternateTraceId(
+                "someTraceId", "operation", Observability.UNDECIDED, rawSupplier);
+
+        assertThatThrownBy(wrappedSupplier::get)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("oopsies");
+        assertThat(Tracer.getTraceId()).isEqualTo(traceIdBeforeConstruction);
+    }
+
+    @SuppressWarnings("ReturnValueIgnored")
+    @Test
+    public void testWrapSupplierWithAlternateTraceId_traceStateRestoredToCleared() {
+        // Clear out the default initialized trace
+        Tracer.getAndClearTraceIfPresent();
+        Tracers.wrapSupplierWithAlternateTraceId("someTraceId", "operation", Observability.UNDECIDED, () -> "hi")
+                .get();
+        assertThat(Tracer.hasTraceId()).isFalse();
+    }
+
+    @SuppressWarnings("ReturnValueIgnored")
+    @Test
+    public void testWrapSupplierWithAlternateTraceId_canSpecifyObservability() {
+        Supplier<String> sampledSupplier = () -> {
+            assertThat(Tracer.getTrace().traceState().isObservable()).isTrue();
+            return "hi";
+        };
+        Supplier<String> wrappedSampledSupplier = Tracers.wrapSupplierWithAlternateTraceId(
+                "someTraceId", "operation", Observability.SAMPLE, sampledSupplier);
+
+        wrappedSampledSupplier.get();
+
+        Supplier<String> unSampledSupplier = () -> {
+            assertThat(Tracer.getTrace().traceState().isObservable()).isFalse();
+            return "hi";
+        };
+        Supplier<String> wrappedUnSampledSupplier = Tracers.wrapSupplierWithAlternateTraceId(
+                "someTraceId", "operation", Observability.DO_NOT_SAMPLE, unSampledSupplier);
+
+        wrappedUnSampledSupplier.get();
+    }
+
     @Test
     public void testTraceIdGeneration() throws Exception {
         assertThat(Tracers.randomId()).hasSize(16); // fails with p=1/16 if generated string is not padded


### PR DESCRIPTION
## Before this PR
https://github.com/palantir/tracing-java/pull/375 added a `wrapWithAlternateTraceId` that takes a Callable. However, Callable's `get()` method has `throws Exception` on it, which forces callers to deal with the possibility of checked exceptions that may not exist.

## After this PR
==COMMIT_MSG==
New Tracers.wrapSupplierWithAlternateTraceId() method
==COMMIT_MSG==

An alternative to `Callable<T>` is `Supplier<T>`, which is nearly the same but without the checked exception on the signature.

Now for callers wrapping code that doesn't declare any checked exceptions don't have to deal with its possibility.

More concretely, callers are required to wrap in a try-catch before:

```
try {
    Tracers.wrapWithAlternateTraceId("someTraceId", "operation", Observability.UNDECIDED, () -> "hi")
        .call();
} catch (Exception e) {
    // not actually possible because () -> "hi" does not throw
    throw new RuntimeException(e);
}
```

and now after with this method, they aren't:

```
Tracers.wrapSupplierWithAlternateTraceId("someTraceId", "operation", Observability.UNDECIDED, () -> "hi")
    .get();
```

## Possible downsides?
- A bit more API surface area.
- can't overload the method name to use `wrapWithAlternateTraceId` like the others, because it creates a compilation ambiguity as called out [here](https://github.com/palantir/tracing-java/pull/375#discussion_r356192460). So have to changer the name to be something else. I chose `wrapSupplierWithAlternateTraceId`